### PR TITLE
Django REST Framework (alt)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,37 @@ Subclassing the authenticated resources in order to add a SameUserAuthentication
 When registered, the APIs will show up at <api_root>/device/apns and <api_root>/device/gcm, respectively.
 
 
+Django REST Framework support
+----------------
+
+The app includes Django REST Framework serializers, views, and routes in push_notifications.django_rest_api. The included
+views allow Django authenticated users to view/add/remove devices associated with their account. These views can be used
+as is or inherited from if you'd like to modify permissions or functionality.
+
+To use the included views, just add the URL routes to your urlpatterns. For example:
+::
+
+	from push_notifications.django_rest_api import gcm_list, apns_list, gcm_detail, apns_detail
+	...
+    # GCM API notifications
+    url(r'^api/devices/gcm/$',
+        gcm_list,
+        name='api_devices_gcm_list'),
+
+    url(r'^api/devices/gcm/(?P<registration_id>[\w-]+)/$',
+        gcm_detail,
+        name='api_devices_gcm_detail'),
+
+    # APNS notifications
+    url(r'^api/devices/apns/$',
+        apns_list,
+        name='api_devices_apns_list'),
+
+    url(r'^api/devices/apns/(?P<registration_id>[\w-]+)/$',
+        apns_detail,
+        name='api_devices_apns_detail'),
+
+
 Python 3 support
 ----------------
 

--- a/push_notifications/django_rest_api.py
+++ b/push_notifications/django_rest_api.py
@@ -1,0 +1,74 @@
+from rest_framework import serializers, permissions, viewsets
+from .models import APNSDevice, GCMDevice
+
+
+class IsOwner(permissions.BasePermission):
+    """
+    Custom permission to only allow owners of an object to see it.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        # Only allow the user to see their own devices
+        return obj.user == request.user
+
+
+class APNSDeviceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = APNSDevice
+        fields = ('name', 'device_id', 'registration_id')
+
+    read_only = ('date_created',)
+
+
+class GCMDeviceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = GCMDevice
+        fields = ('name', 'device_id', 'registration_id')
+
+    read_only = ('date_created',)
+
+
+class DeviceViewSetMixin(object):
+    lookup_field = 'registration_id'
+    queryset = APNSDevice.objects.all()
+    serializer_class = APNSDeviceSerializer
+    permission_classes = (permissions.IsAuthenticated,
+                          IsOwner,)
+
+    def pre_save(self, obj):
+        # Set the requesting user as the device user
+        obj.user = self.request.user
+
+
+class APNSDeviceViewSet(DeviceViewSetMixin, viewsets.ModelViewSet):
+    queryset = APNSDevice.objects.all()
+    serializer_class = APNSDeviceSerializer
+
+
+class GCMDeviceViewSet(DeviceViewSetMixin, viewsets.ModelViewSet):
+    queryset = GCMDevice.objects.all()
+    serializer_class = GCMDeviceSerializer
+
+
+#
+# Links for viewsets
+#
+apns_list = APNSDeviceViewSet.as_view({
+    'get': 'list',
+    'post': 'create'
+})
+
+apns_detail = APNSDeviceViewSet.as_view({
+    'get': 'retrieve',
+    'delete': 'destroy'
+})
+
+gcm_list = GCMDeviceViewSet.as_view({
+    'get': 'list',
+    'post': 'create'
+})
+
+gcm_detail = GCMDeviceViewSet.as_view({
+    'get': 'retrieve',
+    'delete': 'destroy'
+})


### PR DESCRIPTION
Optional serializers, view sets, and URL routes for use with Django REST Framework. The included views allow authenticated users to view/add/remove devices associated with their account. These views can be used as is or inherited from if you'd like to modify permissions or functionality.

Pretty simple to use. Here's an example of how to include the URL routes:

```python
from push_notifications.django_rest_api import gcm_list, apns_list, gcm_detail, apns_detail

# ... in your URL patterns

# GCM API notifications
url(r'^api/devices/gcm/$',
    gcm_list,
    name='api_devices_gcm_list'),

url(r'^api/devices/gcm/(?P<registration_id>[\w-]+)/$',
    gcm_detail,
    name='api_devices_gcm_detail'),

# APNS notifications
url(r'^api/devices/apns/$',
    apns_list,
    name='api_devices_apns_list'),

url(r'^api/devices/apns/(?P<registration_id>[\w-]+)/$',
    apns_detail,
    name='api_devices_apns_detail'),
```