### PR TITLE
Fix Django 1.3 compatibility issue

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -54,7 +54,7 @@ class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerF
 		elif engine == "django.db.backends.sqlite":
 			return "UNSIGNED BIG INT"
 		else:
-			return super(HexIntegerField, self).db_type(connection)
+			return super(HexIntegerField, self).db_type(connection=connection)
 
 	def get_prep_value(self, value):
 		if value is None or value == "":


### PR DESCRIPTION
`./manage.py migrate` was failing with
`db_type() got multiple values for keyword argument 'connection'`
due to a way `call_with_connection` is implemented in `django/db/models/fields/subclassing.py` in Django 1.3