### PR TITLE
django 1.8 compatibility fixes

### DIFF
--- a/push_notifications/migrations/0001_initial.py
+++ b/push_notifications/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import push_notifications.fields
 from django.conf import settings
-import uuidfield.fields
 
 
 class Migration(migrations.Migration):

--- a/push_notifications/migrations/0002_auto_20150329_2211.py
+++ b/push_notifications/migrations/0002_auto_20150329_2211.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import push_notifications.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_notifications', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='apnsdevice',
+            name='device_id',
+            field=models.UUIDField(blank=True, help_text='UDID / UIDevice.identifierForVendor()', null=True, verbose_name='Device ID', db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='gcmdevice',
+            name='device_id',
+            field=push_notifications.fields.HexIntegerField(help_text='ANDROID_ID / TelephonyManager.getDeviceId() (always as hex)', null=True, verbose_name='Device ID', db_index=True, blank=True),
+        ),
+    ]

--- a/push_notifications/migrations/0002_auto_20150329_2211.py
+++ b/push_notifications/migrations/0002_auto_20150329_2211.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='apnsdevice',
             name='device_id',
-            field=models.UUIDField(blank=True, help_text='UDID / UIDevice.identifierForVendor()', null=True, verbose_name='Device ID', db_index=True),
+            field=push_notifications.fields.UUIDField(blank=True, help_text='UDID / UIDevice.identifierForVendor()', null=True, verbose_name='Device ID', db_index=True),
         ),
         migrations.AlterField(
             model_name='gcmdevice',


### PR DESCRIPTION
- removed unnecessary import causing import error 
- added another migration file to use django uuid or ones from uuidfield package 
