### PR TITLE
Add setting to specify CA certificate file for APNS SSL connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,7 @@ For APNS, you are required to include APNS_CERTIFICATE.
 - APNS_PORT: The port used along with APNS_HOST. Defaults to 2195.
 - GCM_POST_URL: The full url that GCM notifications will be POSTed to. Defaults to https://android.googleapis.com/gcm/send.
 - GCM_MAX_RECIPIENTS: The maximum amount of recipients that can be contained per bulk message. If the registration_ids list is larger than that number, multiple bulk messages will be sent. Defaults to 1000 (the maximum amount supported by GCM).
+- CA_CERTS: (Optional) Absolute path to CA certificates file used for APNS SSL connection.
 
 Sending messages
 ----------------

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -33,7 +33,7 @@ class APNSDataOverflow(APNSError):
 
 def _apns_create_socket(address_tuple):
 	certfile = SETTINGS.get("APNS_CERTIFICATE")
-        ca_certs = SETTINGS.get("CA_CERTS")
+	ca_certs = SETTINGS.get("CA_CERTS")
 	if not certfile:
 		raise ImproperlyConfigured(
 			'You need to set PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] to send messages through APNS.'

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -33,6 +33,7 @@ class APNSDataOverflow(APNSError):
 
 def _apns_create_socket(address_tuple):
 	certfile = SETTINGS.get("APNS_CERTIFICATE")
+        ca_certs = SETTINGS.get("CA_CERTS")
 	if not certfile:
 		raise ImproperlyConfigured(
 			'You need to set PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] to send messages through APNS.'
@@ -45,7 +46,7 @@ def _apns_create_socket(address_tuple):
 		raise ImproperlyConfigured("The APNS certificate file at %r is not readable: %s" % (certfile, e))
 
 	sock = socket.socket()
-	sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=certfile)
+	sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=certfile, ca_certs=ca_certs)
 	sock.connect(address_tuple)
 
 	return sock


### PR DESCRIPTION
My server setup requires the CA certificate file to be specified explicitly, so I've added a PUSH_NOTIFICATION setting to specify the file location.