### PR TITLE
Display gcm device_id as hex value in Django admin

### DIFF
--- a/push_notifications/admin.py
+++ b/push_notifications/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
 from .models import APNSDevice, GCMDevice, get_expired_tokens
-
+from django.db import connection
 
 User = get_user_model()
 
@@ -57,5 +57,18 @@ class DeviceAdmin(admin.ModelAdmin):
 			d.save()
 
 
+class GCMDeviceAdmin(DeviceAdmin):
+	"""
+	Inherits from DeviceAdmin to handle displaying gcm device as a hex value
+	"""
+	def device_id_hex(self, obj):
+		if connection.vendor in ("mysql", "sqlite"):
+			return hex(obj.device_id).rstrip("L")
+		else:
+			return obj.device_id
+	device_id_hex.short_description = "Device ID"
+
+	list_display = ("__unicode__", "device_id_hex", "user", "active", "date_created")
+
 admin.site.register(APNSDevice, DeviceAdmin)
-admin.site.register(GCMDevice, DeviceAdmin)
+admin.site.register(GCMDevice, GCMDeviceAdmin)


### PR DESCRIPTION
The value appears as hex in both /admin/push_notifications/gcmdevice/
and /admin/push_notifications/gcmdevice/pk/
Search will work on both integer and hex values. Assume device_ids
0x01, 0x10 and 0x100; a search on 1 would return 0x01(1) and 0x10(16)
but not 0x100(256). A search on 0x1 would return all three devices
but a search on 0x10 would return 0x10 and 0x100