### PR TITLE
Add support of python3 for prune_devices management command

### DIFF
--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -4,6 +4,7 @@ Documentation is available on the iOS Developer Library:
 https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
 """
 
+import codecs
 import json
 import ssl
 import struct
@@ -231,5 +232,5 @@ def apns_fetch_inactive_ids():
 		# Maybe we should have a flag to return the timestamp?
 		# It doesn't seem that useful right now, though.
 		for tStamp, registration_id in _apns_receive_feedback(socket):
-			inactive_ids.append(registration_id.encode('hex'))
+			inactive_ids.append(codecs.encode(registration_id, 'hex_codec'))
 		return inactive_ids

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
 from test_models import *
 from test_gcm_push_payload import *
 from test_apns_push_payload import *
+from test_management_commands import *

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -1,0 +1,25 @@
+import mock
+
+from django.core.management import call_command
+
+from django.test import TestCase
+from push_notifications.apns import _apns_send, APNSDataOverflow
+
+
+class CommandsTestCase(TestCase):
+
+	def test_prune_devices(self):
+		from push_notifications.models import APNSDevice
+
+		device = APNSDevice.objects.create(
+			registration_id="616263",  # hex encoding of b'abc'
+		)
+		with mock.patch(
+				'push_notifications.apns._apns_create_socket_to_feedback',
+				mock.MagicMock()):
+			with mock.patch('push_notifications.apns._apns_receive_feedback',
+					mock.MagicMock()) as receiver:
+				receiver.side_effect = lambda s: [(b'', b'abc')]
+				call_command('prune_devices')
+		device = APNSDevice.objects.get(pk=device.pk)
+		self.assertFalse(device.active)


### PR DESCRIPTION
Under python 3 `rune_devices management command` is failing with the folowing error

```
'bytes' object has no attribute 'encode'
 push_notifications/apns.py, apns_fetch_inactive_ids:234
```
Let's address this issue by using `codecs` module.