### PR TITLE
Add support for http proxy when connecting to APNS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ env:
   - TOXENV=py34-django18
 install:
   - pip install tox
+  - pip install -r requirements.txt
 script:
   - tox -e $TOXENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ env:
   - TOXENV=py34-django18
 install:
   - pip install tox
-  - pip install -r requirements.txt
+  - pip install PySocks
 script:
   - tox -e $TOXENV

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -49,14 +49,14 @@ def _apns_create_socket(address_tuple):
 		raise ImproperlyConfigured("The APNS certificate file at %r is not readable: %s" % (certfile, e))
 
 	ca_certs = SETTINGS.get("APNS_CA_CERTIFICATES")
-	proxy = os.environ.get("https_proxy") # format http://127.0.0.1:8080
+	proxy = os.environ.get("https_proxy")  # format http://127.0.0.1:8080
 
 	if not proxy:
 		sock = socket.socket()
 		sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=certfile, ca_certs=ca_certs)
 		sock.connect(address_tuple)
 	else:
-		sock = socks.socksocket() # Same API as socket.socket in the standard lib
+		sock = socks.socksocket()  # Same API as socket.socket in the standard lib
 		parsed_proxy = urlparse(proxy)
 		sock.set_proxy(socks.HTTP, parsed_proxy.hostname, parsed_proxy.port)
 

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -10,6 +10,9 @@ import ssl
 import struct
 import socket
 import time
+import os
+import socks
+from urlparse import urlparse
 from contextlib import closing
 from binascii import unhexlify
 from django.core.exceptions import ImproperlyConfigured
@@ -46,10 +49,20 @@ def _apns_create_socket(address_tuple):
 		raise ImproperlyConfigured("The APNS certificate file at %r is not readable: %s" % (certfile, e))
 
 	ca_certs = SETTINGS.get("APNS_CA_CERTIFICATES")
+	proxy = os.environ.get("https_proxy") # format http://127.0.0.1:8080
 
-	sock = socket.socket()
-	sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=certfile, ca_certs=ca_certs)
-	sock.connect(address_tuple)
+	if not proxy:
+		sock = socket.socket()
+		sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=certfile, ca_certs=ca_certs)
+		sock.connect(address_tuple)
+	else:
+		sock = socks.socksocket() # Same API as socket.socket in the standard lib
+		parsed_proxy = urlparse(proxy)
+		sock.set_proxy(socks.HTTP, parsed_proxy.hostname, parsed_proxy.port)
+
+		# connect to proxy first, then perform SSL handshake with APNS server
+		sock.connect(address_tuple)
+		sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=certfile, ca_certs=ca_certs)
 
 	return sock
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django
+PySocks


### PR DESCRIPTION
Hi,

if your server is located behind a firewall and you're not able / not allowed or simply don't want to configure your firewall to allow a direct socket connection to the Apple Push Notification Service you may have to / want to use a proxy. Otherwise the connection attempts will fail.

Added support for this use case using the PySocks package.

Best regards,
Basti