### PR TITLE
Add support for http proxy when connecting to APNS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 env:
   - TOXENV=flake8
-  - TOXENV=py27-django18
-  - TOXENV=py33-django18
-  - TOXENV=py34-django18
+  - TOXENV=py27-django18-pysocks154
+  - TOXENV=py33-django18-pysocks154
+  - TOXENV=py34-django18-pysocks154
 install:
   - pip install tox
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django
+PySocks

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = {py27,py33,py34}-django18,flake8
+envlist = {py27,py33,py34}-django18,flake8,{py27,py33,py34}-pysocks154
 
 [testenv]
 commands = python ./tests/runtests.py
 deps=
   django18: Django==1.8.2
   mock==1.0.1
+  pysocks154: PySocks==1.5.4
 
 [testenv:flake8]
 commands = flake8 push_notifications


### PR DESCRIPTION
Hi,

if your server is located behind a firewall and you're not able / not allowed or simply don't want to configure your firewall to allow a direct socket connection to the Apple Push Notification Service you may have to / want to use a proxy. Otherwise the connection attempts will fail.

Added support for this use case using the PySocks package.

Best regards,
Basti