### PR TITLE
Fixed bug that caused an error when creating or updating a gcm device

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -79,3 +79,7 @@ class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerF
 		defaults.update(kwargs)
 		# yes, that super call is right
 		return super(models.IntegerField, self).formfield(**defaults)
+
+	def run_validators(self, value):
+		# make sure validation is performed on integer value not string value
+		return super(models.BigIntegerField, self).run_validators(self.get_prep_value(value))


### PR DESCRIPTION
When either postgres or mysql is selected as the database engine
attempts to create or update a gcm device using a form and http post
will fail.  The validators were being run against a string value
thus min and max validation were failing.