### PR TITLE
Fix DeviceViewSetMixin when user is not authenticated

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -70,6 +70,7 @@ class DeviceViewSetMixin(object):
 	def perform_create(self, serializer):
 		if self.request.user.is_authenticated():
 			serializer.save(user=self.request.user)
+		return super(DeviceViewSetMixin, self).perform_create(serializer)
 
 
 class AuthorizedMixin(object):


### PR DESCRIPTION
Call the perform_create of the super so it also will save the serializer when the user is not authenticated.