### PR TITLE
Model defaults ignored on empty boolean field

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -38,6 +38,9 @@ class DeviceSerializerMixin(ModelSerializer):
 		fields = ("name", "registration_id", "device_id", "active", "date_created")
 		read_only_fields = ("date_created", )
 
+		# See https://github.com/tomchristie/django-rest-framework/issues/1101
+		extra_kwargs = {"active": {"default": True}}
+
 
 class APNSDeviceSerializer(ModelSerializer):
 


### PR DESCRIPTION
https://github.com/tomchristie/django-rest-framework/issues/1101
This bug still happens in drf version 3.2.3