### PR TITLE
Adds active filter in APNS and GCM query sets.

### DIFF
--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -38,7 +38,7 @@ class GCMDeviceQuerySet(models.query.QuerySet):
 			if message is not None:
 				data["message"] = message
 
-			reg_ids = [rec.registration_id for rec in self]
+			reg_ids = [rec.registration_id for rec in self if rec.active]
 			return gcm_send_bulk_message(registration_ids=reg_ids, data=data, **kwargs)
 
 
@@ -72,7 +72,7 @@ class APNSDeviceQuerySet(models.query.QuerySet):
 	def send_message(self, message, **kwargs):
 		if self:
 			from .apns import apns_send_bulk_message
-			reg_ids = [rec.registration_id for rec in self]
+			reg_ids = [rec.registration_id for rec in self if rec.active]
 			return apns_send_bulk_message(registration_ids=reg_ids, alert=message, **kwargs)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -72,6 +72,25 @@ class ModelTestCase(TestCase):
                     "registration_ids": ["abc", "abc1"]
                 }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
 
+    def test_gcm_send_message_active_devices(self):
+        GCMDevice.objects.create(
+            registration_id="abc",
+            active=True
+        )
+
+        GCMDevice.objects.create(
+            registration_id="xyz",
+            active=False
+        )
+
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE) as p:
+            GCMDevice.objects.all().send_message("Hello world")
+            p.assert_called_once_with(
+                json.dumps({
+                    "data": { "message": "Hello world" },
+                    "registration_ids": ["abc"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+
     def test_gcm_send_message_extra_to_multiple_devices(self):
         GCMDevice.objects.create(
             registration_id="abc",


### PR DESCRIPTION
Since we intend to send notifications only to the active devices. Active filter should be in the query set.
I have added this check in both APNS and GCM querysets. Please review it.

Thanks,

Avichalp 