### PR TITLE
Added support for multiple APNS certificates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,12 @@ Edit your settings.py file:
 
 	PUSH_NOTIFICATIONS_SETTINGS = {
 		"GCM_API_KEY": "<your api key>",
-		"APNS_CERTIFICATE": "/path/to/your/certificate.pem",
+		"APNS_APP_CERTIFICATES": {
+			"YOUR_APP_NAME": {
+				"APNS_CERTIFICATE": "/path/to/your/certificate.pem",
+			}
+		}
+
 	}
 
 .. note::
@@ -66,8 +71,11 @@ All settings are contained in a ``PUSH_NOTIFICATIONS_SETTINGS`` dict.
 In order to use GCM, you are required to include ``GCM_API_KEY``.
 For APNS, you are required to include ``APNS_CERTIFICATE``.
 
-- ``APNS_CERTIFICATE``: Absolute path to your APNS certificate file. Certificates with passphrases are not supported.
-- ``APNS_CA_CERTIFICATES``: Absolute path to a CA certificates file for APNS. Optional - do not set if not needed. Defaults to None.
+- ``APNS_APP_CERTIFICATES``: A dictionary where the keys are your iOS app names and the values dictionaries with:
+	- ``APNS_CERTIFICATE``: Absolute path to your APNS certificate file. Certificates with passphrases are not supported.
+	- ``APNS_CA_CERTIFICATES``: Absolute path to a CA certificates file for APNS. Optional - do not set if not needed. Defaults to None.
+	- ``APNS_HOST``: The hostname used with this certificate for the APNS sockets. Optional - will default to the value of ``APNS_HOST``.
+	- ``APNS_PORT``: The port used used with this certificate. Optional - will default to the value of ``APNS_PORT``.
 - ``GCM_API_KEY``: Your API key for GCM.
 - ``APNS_HOST``: The hostname used for the APNS sockets.
    - When ``DEBUG=True``, this defaults to ``gateway.sandbox.push.apple.com``.
@@ -99,6 +107,13 @@ GCM and APNS services have slightly different semantics. The app tries to offer 
 	device.send_message("You've got mail") # Alert message may only be sent as text.
 	device.send_message(None, badge=5) # No alerts but with badge.
 	device.send_message(None, badge=1, extra={"foo": "bar"}) # Silent message with badge and added custom data.
+
+	# If you have more then one app on your APNS_APP_CERTIFICATES settings you
+	# must use the app_name kwarg to specify the target app.
+	# You will have an error otherwise.
+	device.send_message("You've got mail", app_name="MailApp")
+	device.send_message("You've got mail", app_name="MailNSALoggerApp")
+
 
 .. note::
 	APNS does not support sending payloads that exceed 2048 bytes (increased from 256 in 2014).

--- a/dev.requirements.txt
+++ b/dev.requirements.txt
@@ -1,0 +1,3 @@
+tox
+mock
+-r requirements.txt

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -32,34 +32,76 @@ class APNSDataOverflow(APNSError):
 	pass
 
 
-def _apns_create_socket(address_tuple):
-	certfile = SETTINGS.get("APNS_CERTIFICATE")
-	if not certfile:
-		raise ImproperlyConfigured(
-			'You need to set PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] to send messages through APNS.'
-		)
+class APNSCert(object):
 
-	try:
-		with open(certfile, "r") as f:
-			f.read()
-	except Exception as e:
-		raise ImproperlyConfigured("The APNS certificate file at %r is not readable: %s" % (certfile, e))
+	def _get_app_settings(self, name=None):
+		app_settings = SETTINGS.get("APNS_APP_CERTIFICATES", None)
+		if not app_settings:
+			# rewrite single certificate config if possible
+			cert = SETTINGS.get("APNS_CERTIFICATE", None)
+			if cert:
+				app_settings["APNS_APP_CERTIFICATES"] = {
+					"default": {
+						"APNS_CERTIFICATE": cert,
+						"APNS_CA_CERTIFICATES": SETTINGS.get("APNS_CA_CERTIFICATES", None)
+					}
+				}
+			else:
+				# always suggest the user use the new APNS_APP_CERTIFICATES if neither is configured
+				raise ImproperlyConfigured(
+					"You need to set PUSH_NOTIFICATIONS_SETTINGS['APNS_APP_CERTIFICATES'] to send messages through APNS."
+				)
 
-	ca_certs = SETTINGS.get("APNS_CA_CERTIFICATES")
+		if not name:
+			if len(app_settings) > 1:
+				raise ValueError(
+					"More than 2 apps -> Please specify the one to use by passing a name."
+				)
+			return list(app_settings.values())[0]
+		try:
+			return app_settings[name]
+		except KeyError:
+			raise ValueError(
+					"App name '{n}' doesn't exist on APNS_APP_CERTIFICATES settings.".format(n=name)
+				)
 
+	def __init__(self, app_name=None):
+		# validation of APNS_CERTIFICATE and APNS_CA_CERTIFICATES is handled in checks.py. A missing app name will
+		# trigger a runtime ValueError in _get_app_settings.
+		settings = self._get_app_settings(name=app_name)
+		self.cert = settings.get("APNS_CERTIFICATE")
+		self.ca_cert = settings.get("APNS_CA_CERTIFICATES")
+
+		# Allow specific host/port settings for each certificate but fall back on the default
+		self.host = settings.get("APNS_HOST", SETTINGS["APNS_HOST"])
+		self.port = settings.get("APNS_PORT", SETTINGS["APNS_PORT"])
+
+
+def _apns_create_socket(address_tuple, cert, ca_cert):
 	sock = socket.socket()
-	sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=certfile, ca_certs=ca_certs)
+	sock = ssl.wrap_socket(sock, ssl_version=ssl.PROTOCOL_TLSv1, certfile=cert, ca_certs=ca_cert)
 	sock.connect(address_tuple)
 
 	return sock
 
 
-def _apns_create_socket_to_push():
-	return _apns_create_socket((SETTINGS["APNS_HOST"], SETTINGS["APNS_PORT"]))
+def _apns_create_socket_to_push(app_name=None):
+	cert = APNSCert(app_name=app_name)
+
+	return _apns_create_socket(
+		(cert.host, cert.port),
+		cert.cert,
+		cert.ca_cert
+	)
 
 
-def _apns_create_socket_to_feedback():
-	return _apns_create_socket((SETTINGS["APNS_FEEDBACK_HOST"], SETTINGS["APNS_FEEDBACK_PORT"]))
+def _apns_create_socket_to_feedback(app_name=None):
+	cert = APNSCert(app_name=app_name)
+	return _apns_create_socket(
+		(SETTINGS["APNS_FEEDBACK_HOST"], SETTINGS["APNS_FEEDBACK_PORT"]),
+		cert.cert,
+		cert.ca_cert
+	)
 
 
 def _apns_pack_frame(token_hex, payload, identifier, expiration, priority):
@@ -104,7 +146,7 @@ def _apns_check_errors(sock):
 
 def _apns_send(token, alert, badge=None, sound=None, category=None, content_available=False,
 	action_loc_key=None, loc_key=None, loc_args=[], extra={}, identifier=0,
-	expiration=None, priority=10, socket=None):
+	expiration=None, priority=10, socket=None, app_name=None):
 	data = {}
 	aps_data = {}
 
@@ -150,7 +192,7 @@ def _apns_send(token, alert, badge=None, sound=None, category=None, content_avai
 	if socket:
 		socket.write(frame)
 	else:
-		with closing(_apns_create_socket_to_push()) as socket:
+		with closing(_apns_create_socket_to_push(app_name=app_name)) as socket:
 			socket.write(frame)
 			_apns_check_errors(socket)
 
@@ -168,7 +210,7 @@ def _apns_receive_feedback(socket):
 	expired_token_list = []
 
 	# read a timestamp (4 bytes) and device token length (2 bytes)
-	header_format = '!LH'
+	header_format = "!LH"
 	has_data = True
 	while has_data:
 		try:
@@ -177,7 +219,7 @@ def _apns_receive_feedback(socket):
 			if header_data is not None:
 				timestamp, token_length = header_data
 				# Unpack format for a single value of length bytes
-				token_format = '%ss' % token_length
+				token_format = "%ss" % token_length
 				device_token = _apns_read_and_unpack(socket, token_format)
 				if device_token is not None:
 					# _apns_read_and_unpack returns a tuple, but
@@ -209,7 +251,7 @@ def apns_send_message(registration_id, alert, **kwargs):
 	_apns_send(registration_id, alert, **kwargs)
 
 
-def apns_send_bulk_message(registration_ids, alert, **kwargs):
+def apns_send_bulk_message(registration_ids, alert, app_name=None, **kwargs):
 	"""
 	Sends an APNS notification to one or more registration_ids.
 	The registration_ids argument needs to be a list.
@@ -218,21 +260,21 @@ def apns_send_bulk_message(registration_ids, alert, **kwargs):
 	it won't be included in the notification. You will need to pass None
 	to this for silent notifications.
 	"""
-	with closing(_apns_create_socket_to_push()) as socket:
+	with closing(_apns_create_socket_to_push(app_name=app_name)) as socket:
 		for identifier, registration_id in enumerate(registration_ids):
 			_apns_send(registration_id, alert, identifier=identifier, socket=socket, **kwargs)
 		_apns_check_errors(socket)
 
 
-def apns_fetch_inactive_ids():
+def apns_fetch_inactive_ids(app_name=None):
 	"""
 	Queries the APNS server for id's that are no longer active since
 	the last fetch
 	"""
-	with closing(_apns_create_socket_to_feedback()) as socket:
+	with closing(_apns_create_socket_to_feedback(app_name=app_name)) as socket:
 		inactive_ids = []
 		# Maybe we should have a flag to return the timestamp?
 		# It doesn't seem that useful right now, though.
 		for tStamp, registration_id in _apns_receive_feedback(socket):
-			inactive_ids.append(codecs.encode(registration_id, 'hex_codec'))
+			inactive_ids.append(codecs.encode(registration_id, "hex_codec"))
 		return inactive_ids

--- a/push_notifications/checks.py
+++ b/push_notifications/checks.py
@@ -1,0 +1,88 @@
+from django.core import checks
+from django.utils.translation import ugettext as _
+
+# Minimum Django version required for Django Push Notifications to run.
+DJANGO_MINIMUM_REQUIRED_VERSION = (1, 8, 0)
+
+
+def _version_to_string(version, significance=None):
+	if significance is not None:
+		version = version[significance:]
+	return ".".join(str(n) for n in version)
+
+
+@checks.register()
+def check_library_versions(app_configs=None, **kwargs):
+	from django import VERSION as django_version
+
+	errors = []
+
+	if django_version < DJANGO_MINIMUM_REQUIRED_VERSION:
+		errors.append(checks.Critical(
+			_("Your version of Django is too old."),
+			hint=_("Try pip install --upgrade 'Django==%s'", _version_to_string(DJANGO_MINIMUM_REQUIRED_VERSION)),
+			id="django_push_notifications.C001",
+		))
+
+	return errors
+
+
+@checks.register()
+def check_apns_settings(app_configs=None, **kwargs):
+	from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+	dpn_settings = SETTINGS.copy()
+
+	errors = []
+
+	if "APNS_CERTIFICATE" in dpn_settings:
+		cert = dpn_settings.pop("APNS_CERTIFICATE", None)
+		ca_cert = dpn_settings.pop("APNS_CA_CERTIFICATES", None)
+
+		dpn_settings["APNS_APP_CERTIFICATES"] = {
+			"APP": {
+				"APNS_CERTIFICATE": cert,
+				"APNS_CA_CERTIFICATES": ca_cert
+			}
+		}
+
+		errors.append(checks.Warning(
+			_("Use the new APNS Certificates format."),
+			hint="""
+			Here is how to format your current settings:
+			{s}
+			""".format(s=dpn_settings),
+			id="django_push_notifications.W001"
+		))
+
+	if "APNS_APP_CERTIFICATES" in SETTINGS:
+		apns_app_settings = SETTINGS.get("APNS_APP_CERTIFICATES", None)
+		if not len(apns_app_settings):
+			errors.append(checks.Error(
+				_('You need to set at least one app in ["APNS_APP_CERTIFICATES"] to send messages through APNS.'),
+				id="django_push_notifications.E001"
+			))
+
+		for app_name, certificate_settings in apns_app_settings.items():
+			cert = certificate_settings.get("APNS_CERTIFICATE", None)
+			if not cert:
+				errors.append(checks.Error(
+					_("Missing certificate for APP {name}").format(name=app_name),
+					id="django_push_notifications.E002",
+					hint=_('Set PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"]["{name}"]["APNS_CERTIFICATE"]')
+				))
+			else:
+				# ensure the certificate is readable
+				try:
+					with open(cert, "r") as f:
+						f.read()
+				except Exception as ex:
+					errors.append(checks.Error(
+						_("The APNS certificate file for {app} at {path} is not readable: {ex}").format(
+							app=app_name,
+							path=cert,
+							ex=ex
+						),
+						id="django_push_notifications.E003",
+					))
+
+	return errors

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,9 @@
 from test_models import *
 from test_gcm_push_payload import *
 from test_apns_push_payload import *
+from test_apns_certificates_settings import *
 from test_management_commands import *
+
 
 # conditionally test rest_framework api if the DRF package is installed
 try:

--- a/tests/test_apns_certificates_settings.py
+++ b/tests/test_apns_certificates_settings.py
@@ -1,0 +1,110 @@
+import warnings
+import mock
+
+from django.test import TestCase
+from django.core.exceptions import ImproperlyConfigured
+from push_notifications import settings as SETTINGS
+from push_notifications.apns import APNSCert
+from push_notifications import checks
+
+
+class APNSCertificateSettingsTest(TestCase):
+
+	def tearDown(self):
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS.pop("APNS_CERTIFICATE", None)
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS.pop("APNS_CA_CERTIFICATES", None)
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS.pop("APNS_APP_CERTIFICATES", None)
+
+	def test_old_apns_certificate_check(self):
+		"""Force the user to upgrade to the new certificate settings format."""
+
+		# confirm check if APNS_CERTIFICATE is set
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] = "/dev/null"
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_CA_CERTIFICATES"] =  None
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS.pop("APNS_APP_CERTIFICATES", None)
+
+		errors = checks.check_apns_settings()
+		self.assertEqual(1, len(errors))
+		self.assertEqual(errors[0].id, "django_push_notifications.W001")
+
+		# confirm check is not raised if APNS_CERTIFICATE is not set
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS.pop("APNS_CERTIFICATE", None)
+
+		errors = checks.check_apns_settings()
+		self.assertEqual(0, len(errors))
+
+	def test_apns_app_certificates_check(self):
+		"""Validate system checks for APNS_APP_CERTIFICATES setting."""
+
+		# django_push_notifications.C003 - at least one app defined
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"] = {}
+
+		errors = checks.check_apns_settings()
+		self.assertEqual(1, len(errors))
+		self.assertEqual(errors[0].id, "django_push_notifications.E001")
+
+		# django_push_notifications.C004 - APNS_CERTIFICATE define for app
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"] = {
+			"app": {}
+		}
+
+		errors = checks.check_apns_settings()
+		self.assertEqual(1, len(errors))
+		self.assertEqual(errors[0].id, "django_push_notifications.E002")
+
+		# django_push_notifications.C005 - APNS_CERTIFICATE is readable
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"] = {
+			"app": {
+				"APNS_CERTIFICATE": "/tmp/doesnotexist"  # not readable
+			}
+		}
+
+		errors = checks.check_apns_settings()
+		self.assertEqual(1, len(errors))
+		self.assertEqual(errors[0].id, "django_push_notifications.E003")
+
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"] = {
+			"app": {
+				"APNS_CERTIFICATE": "/dev/null"  # readable
+			}
+		}
+
+		errors = checks.check_apns_settings()
+		self.assertEqual(0, len(errors))
+
+	def test_single_apps(self):
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"] = {
+					"App1": {
+						"APNS_CERTIFICATE": "/dev/null",
+						"APNS_CA_CERTIFICATES": "/dev/null"
+					}
+		}
+		wrapper = APNSCert()
+		app1 = SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"]["App1"]
+		self.assertEquals(wrapper.cert, app1["APNS_CERTIFICATE"])
+		self.assertEquals(wrapper.ca_cert, app1["APNS_CA_CERTIFICATES"])
+
+		with self.assertRaises(ImproperlyConfigured):
+			SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"] = {}
+			APNSCert()
+		with self.assertRaises(ImproperlyConfigured):
+			SETTINGS.PUSH_NOTIFICATIONS_SETTINGS.pop("APNS_APP_CERTIFICATES", None)
+			APNSCert()
+
+	def test_multiple_apps(self):
+		SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"] = {
+					"App1": {
+						"APNS_CERTIFICATE": "/dev/null",
+						"APNS_CA_CERTIFICATES": None
+					},
+					"App2": {
+						"APNS_CERTIFICATE": "/dev/null",
+						"APNS_CA_CERTIFICATES": None
+					}
+		}
+		wrapper = APNSCert(app_name="App2")
+		app1 = SETTINGS.PUSH_NOTIFICATIONS_SETTINGS["APNS_APP_CERTIFICATES"]["App2"]
+		self.assertEquals(wrapper.cert, app1["APNS_CERTIFICATE"])
+		self.assertIsNone(wrapper.ca_cert, app1["APNS_CA_CERTIFICATES"])
+		with self.assertRaises(ValueError):
+			APNSCert(app_name="Bogus")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -210,6 +210,17 @@ class ModelTestCase(TestCase):
             device.send_message("Hello world", socket=socket, expiration=1)
             p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
 
+    def test_apns_send_message_for_specific_app(self):
+        device = APNSDevice.objects.create(
+            registration_id="abc",
+        )
+        socket = mock.MagicMock()
+        with mock.patch("push_notifications.apns._apns_send") as p:
+            device.send_message("Hello world for HelloApp", socket=socket, expiration=1,
+                app_name="HelloApp")
+            a, k = p.call_args
+            self.assertEquals(k["app_name"], "HelloApp")
+
     def test_apns_send_message_extra(self):
         device = APNSDevice.objects.create(
             registration_id="abc",


### PR DESCRIPTION
Supersedes PR #182.

This update introduces a new setting, APNS_APP_CERTIFICATES, and forcefully
requires developers to replace APNS_CERTIFICATE. Settings are
validated at startup using Django system checks. Based on the work of
@cristiano2lopes with minor updates to address outstanding issues
mentioned by the package maintainer.

Fixes: #130