### PR TITLE
Correcting rest framework validation of GCMDevice.device_id max value.

### DIFF
--- a/push_notifications/admin.py
+++ b/push_notifications/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
 from .models import APNSDevice, GCMDevice, get_expired_tokens
-from django.db import connection
+
 
 User = get_user_model()
 
@@ -57,18 +57,5 @@ class DeviceAdmin(admin.ModelAdmin):
 			d.save()
 
 
-class GCMDeviceAdmin(DeviceAdmin):
-	"""
-	Inherits from DeviceAdmin to handle displaying gcm device as a hex value
-	"""
-	def device_id_hex(self, obj):
-		if connection.vendor in ("mysql", "sqlite") and obj.device_id:
-			return hex(obj.device_id).rstrip("L")
-		else:
-			return obj.device_id
-	device_id_hex.short_description = "Device ID"
-
-	list_display = ("__str__", "device_id_hex", "user", "active", "date_created")
-
 admin.site.register(APNSDevice, DeviceAdmin)
-admin.site.register(GCMDevice, GCMDeviceAdmin)
+admin.site.register(GCMDevice, DeviceAdmin)

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from django.db.backends.base.operations import BaseDatabaseOperations
 from rest_framework import permissions
 from rest_framework.serializers import ModelSerializer, ValidationError
 from rest_framework.validators import UniqueValidator
@@ -9,9 +8,7 @@ from rest_framework.fields import IntegerField
 
 from push_notifications.models import APNSDevice, GCMDevice
 from push_notifications.fields import hex_re
-
-
-BIGINT_MAX_VALUE = BaseDatabaseOperations.integer_field_ranges["BigIntegerField"][1]
+from push_notifications.fields import UNSIGNED_64BIT_INT_MAX_VALUE
 
 # Fields
 
@@ -22,7 +19,8 @@ class HexIntegerField(IntegerField):
 	"""
 
 	def to_internal_value(self, data):
-		# validate that value is a hex number
+		# validate hex string and convert it to the unsigned
+		# integer representation for internal use
 		try:
 			data = int(data, 16)
 		except ValueError:
@@ -78,9 +76,8 @@ class GCMDeviceSerializer(ModelSerializer):
 		}
 
 	def validate_device_id(self, value):
-		# max value for django.db.models.BigIntegerField is 9223372036854775807
-		# make sure the value is in valid range
-		if value > BIGINT_MAX_VALUE:
+		# device ids are 64 bit unsigned values
+		if value > UNSIGNED_64BIT_INT_MAX_VALUE:
 			raise ValidationError("ValidationError Device ID is out of range")
 		return value
 

--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -1,20 +1,45 @@
 import re
 import struct
 from django import forms
+from django.core.validators import MaxValueValidator
+from django.core.validators import MinValueValidator
 from django.core.validators import RegexValidator
 from django.db import models, connection
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
+UNSIGNED_64BIT_INT_MIN_VALUE = 0
+UNSIGNED_64BIT_INT_MAX_VALUE = 2 ** 64 - 1
 
 __all__ = ["HexadecimalField", "HexIntegerField"]
 
 
 hex_re = re.compile(r"^(([0-9A-f])|(0x[0-9A-f]))+$")
-postgres_engines = [
+signed_integer_engines = [
 	"django.db.backends.postgresql_psycopg2",
 	"django.contrib.gis.db.backends.postgis",
+	"django.db.backends.sqlite3"
 ]
+
+
+def _using_signed_storage():
+	return connection.settings_dict["ENGINE"] in signed_integer_engines
+
+
+def _signed_to_unsigned_integer(value):
+	return struct.unpack("Q", struct.pack("q", value))[0]
+
+
+def _unsigned_to_signed_integer(value):
+	return struct.unpack("q", struct.pack("Q", value))[0]
+
+
+def _hex_string_to_unsigned_integer(value):
+	return int(value, 16)
+
+
+def _unsigned_integer_to_hex_string(value):
+	return hex(value).rstrip("L")
 
 
 class HexadecimalField(forms.CharField):
@@ -29,7 +54,7 @@ class HexadecimalField(forms.CharField):
 		# converts bigint from db to hex before it is displayed in admin
 		if value and not isinstance(value, six.string_types) \
 			and connection.vendor in ("mysql", "sqlite"):
-			value = hex(value).rstrip("L")
+			value = _unsigned_integer_to_hex_string(value)
 		return super(forms.CharField, self).prepare_value(value)
 
 
@@ -45,6 +70,12 @@ class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerF
 	On sqlite and mysql, native unsigned bigint types are used. In all cases, the
 	value we deal with in python is always in hex.
 	"""
+
+	validators = [
+		MinValueValidator(UNSIGNED_64BIT_INT_MIN_VALUE),
+		MaxValueValidator(UNSIGNED_64BIT_INT_MAX_VALUE)
+	]
+
 	def db_type(self, connection):
 		engine = connection.settings_dict["ENGINE"]
 		if "mysql" in engine:
@@ -55,24 +86,30 @@ class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerF
 			return super(HexIntegerField, self).db_type(connection=connection)
 
 	def get_prep_value(self, value):
+		""" Return the integer value to be stored from the hex string """
 		if value is None or value == "":
 			return None
 		if isinstance(value, six.string_types):
-			value = int(value, 16)
-		# on postgres only, interpret as signed
-		if connection.settings_dict["ENGINE"] in postgres_engines:
-			value = struct.unpack("q", struct.pack("Q", value))[0]
+			value = _hex_string_to_unsigned_integer(value)
+		if _using_signed_storage():
+			value = _unsigned_to_signed_integer(value)
+		return value
+
+	def from_db_value(self, value, expression, connection, context):
+		""" Return an unsigned int representation from all db backends """
+		if value is None:
+			return value
+		if _using_signed_storage():
+			value = _signed_to_unsigned_integer(value)
 		return value
 
 	def to_python(self, value):
+		""" Return a str representation of the hexadecimal """
 		if isinstance(value, six.string_types):
 			return value
 		if value is None:
 			return ""
-		# on postgres only, re-interpret from signed to unsigned
-		if connection.settings_dict["ENGINE"] in postgres_engines:
-			value = hex(struct.unpack("Q", struct.pack("q", value))[0])
-		return value
+		return _unsigned_integer_to_hex_string(value)
 
 	def formfield(self, **kwargs):
 		defaults = {"form_class": HexadecimalField}
@@ -82,4 +119,5 @@ class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerF
 
 	def run_validators(self, value):
 		# make sure validation is performed on integer value not string value
-		return super(models.BigIntegerField, self).run_validators(self.get_prep_value(value))
+		value = _hex_string_to_unsigned_integer(value)
+		return super(models.BigIntegerField, self).run_validators(value)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -87,7 +87,19 @@ class GCMDeviceSerializerTestCase(TestCase):
 		serializer = GCMDeviceSerializer(data={
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
-			"device_id": "a54eb38370070a1b",
+			"device_id": "10000000000000000", # 2**64
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors, GCM_DRF_OUT_OF_RANGE_ERROR)
+
+	def test_device_id_validation_value_between_signed_unsigned_64b_int_maximums(self):
+		"""
+		2**63 < 0xe87a4e72d634997c < 2**64
+		"""
+		serializer = GCMDeviceSerializer(data={
+			"registration_id": "foobar",
+			"name": "Nexus 5",
+			"device_id": "e87a4e72d634997c",
+		})
+		self.assertTrue(serializer.is_valid())
+


### PR DESCRIPTION
Half of the valid GCM device_id range currently elicits a `ValidationError` due to incorrect validation added in e8d07766e2e89b6ff176e386e88039a3c8cc1554, whereby the submitted value is checked against the signed 64 bit integer maximum rather than the unsigned.