### PR TITLE
Added djangorestframework to tox deps list.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ commands = python ./tests/runtests.py
 deps=
   django18: Django==1.8.2
   mock==1.0.1
+  djangorestframework==3.2.4
 
 [testenv:flake8]
 commands = flake8 push_notifications


### PR DESCRIPTION
The tests in test_rest_framework were not running because they require djangorestframework.