### PR TITLE
Dropped support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
-env:
-  - TOXENV=flake8
-  - TOXENV=py27-django18
-  - TOXENV=py33-django18
-  - TOXENV=py34-django18
+addons:
+  apt:
+    sources:
+    - deadsnakes
+    packages:
+    - python3.5
 install:
   - pip install tox
 script:
-  - tox -e $TOXENV
+  - tox
 sudo: false

--- a/README.rst
+++ b/README.rst
@@ -214,6 +214,6 @@ Routes can be added one of two ways:
 Python 3 support
 ----------------
 
-``django-push-notifications`` is fully compatible with Python 3.
+``django-push-notifications`` is fully compatible with Python 3.4 & 3.5
 
 .. [1] Any devices which are not selected, but are not receiving notifications will not be deactivated on a subsequent call to "prune devices" unless another attempt to send a message to the device fails after the call to the feedback service.

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,8 @@ CLASSIFIERS = [
 	"License :: OSI Approved :: MIT License",
 	"Programming Language :: Python",
 	"Programming Language :: Python :: 2.7",
-	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.3",
 	"Programming Language :: Python :: 3.4",
+	"Programming Language :: Python :: 3.5",
 	"Topic :: Software Development :: Libraries :: Python Modules",
 	"Topic :: System :: Networking",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = {py27,py33,py34}-django18,flake8
+envlist = {py27,py34,py35}--django{18,19}--drf{32,33},flake8
 
 [testenv]
 commands = python ./tests/runtests.py
 deps=
-  django18: Django==1.8.2
+  django18: Django>=1.8,<1.9
+  django19: Django>=1.9,<2.0
   mock==1.0.1
-  djangorestframework==3.2.4
+  drf32: djangorestframework>=3.2,<3.3
+  drf33: djangorestframework>=3.3,<3.4
 
 [testenv:flake8]
 commands = flake8 push_notifications


### PR DESCRIPTION
Added Django 1.9 to tox test environment
Fixed tox.ini to properly test against all supported
versions of Python, Django and Django Rest Framework