### PR TITLE
Fixes an index error that is thrown in the django admin.

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -108,7 +108,7 @@ class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerF
 		if isinstance(value, six.string_types):
 			return value
 		if value is None:
-			return ""
+			return value
 		return _unsigned_integer_to_hex_string(value)
 
 	def formfield(self, **kwargs):


### PR DESCRIPTION
On Django 1.9 if the gcm device id is null, an error is thrown
on the to_python method of the HexIntegerField class.