### PR TITLE
Removed call to with_metaclass as it is no longer needed

### DIFF
--- a/push_notifications/fields.py
+++ b/push_notifications/fields.py
@@ -58,7 +58,7 @@ class HexadecimalField(forms.CharField):
 		return super(forms.CharField, self).prepare_value(value)
 
 
-class HexIntegerField(six.with_metaclass(models.SubfieldBase, models.BigIntegerField)):
+class HexIntegerField(models.BigIntegerField):
 	"""
 	This field stores a hexadecimal *string* of up to 64 bits as an unsigned integer
 	on *all* backends including postgres.


### PR DESCRIPTION
Subfieldbase is deprecated and scheduled to be removed with Django
1.10