### PR TITLE
Full implementation for multiple mobile applications (solves #130, supercedes #226)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ GCM or APNS devices and in the action dropdown, select "Send test message" or "S
 Note that sending a non-bulk test message to more than one device will just iterate over the devices and send multiple
 single messages.
 
+The application supports multiple mobile applications with separate application IDs using one server simultaneously.
+
 Dependencies
 ------------
 Django 1.8 is required. Support for older versions is available in the release 1.2.1.
@@ -63,13 +65,27 @@ Settings list
 -------------
 All settings are contained in a ``PUSH_NOTIFICATIONS_SETTINGS`` dict.
 
-In order to use GCM, you are required to include ``GCM_API_KEY``.
-For APNS, you are required to include ``APNS_CERTIFICATE``.
+In order to use GCM, you are required to include one of ``GCM_API_KEY``, ``GCM_API_KEYS``, or ``GCM_API_KEYS_MODEL``.
+For APNS, you are required to include ``APNS_CERTIFICATE``, ``APNS_CERTIFICATES``, or ``APNS_CERTIFICATES_MODEL``.
 
 - ``APNS_CERTIFICATE``: Absolute path to your APNS certificate file. Certificates with passphrases are not supported.
+- ``APNS_CERTIFICATES``: A dictionary reflecting separate application IDs to separate APNS certificate files.
+- ``APNS_CERTIFICATES_MODEL``: A dictionary containing description of a database model to reflect
+  application ID to APNS certificate file path.
+    - ``'model'`` - a model name like ``'my_application.MyModel'``
+    - ``'key'`` - a field name of the model referenced above, containing an application ID like ``'application_id'``
+    - ``'value'`` - a path to the field from the model referenced above, which contains an APNS certificate
+      file path, or just having a type django.db.models.fields.FileField, like ``'certificate'``
 - ``APNS_CA_CERTIFICATES``: Absolute path to a CA certificates file for APNS. Optional - do not set if not needed. Defaults to None.
 - ``GCM_API_KEY``: Your API key for GCM.
-- ``APNS_HOST``: The hostname used for the APNS sockets.
+- ``GCM_API_KEYS``: A dictionary reflecting separate application IDs to separate GCM API keys.
+- ``GCM_API_KEYS_MODEL``: A dictionary reflecting separate application IDs to separate GCM API
+  keys.
+    - ``'model'`` - a model name like ``'my_application.MyModel'``
+    - ``'key'`` - a field name of the model referenced above, containing an application ID like ``'application_id'``
+    - ``'value'`` - a path to the field from the model referenced above, which contains a GCM API key like ``'api_key'``
+- ``APNS_HOST``: The hostname used for the APNS
+  sockets.
    - When ``DEBUG=True``, this defaults to ``gateway.sandbox.push.apple.com``.
    - When ``DEBUG=False``, this defaults to ``gateway.push.apple.com``.
 - ``APNS_PORT``: The port used along with APNS_HOST. Defaults to 2195.
@@ -116,6 +132,73 @@ Sending messages in bulk
 
 Sending messages in bulk makes use of the bulk mechanics offered by GCM and APNS. It is almost always preferable to send
 bulk notifications instead of single ones.
+
+Multiple mobile applications
+----------------------------
+
+In order to use multiple mobile applications on the same server, you should provide some method to associate the application IDs
+and correspondent application keys or certificates.
+
+If your are planning to use some not big and static number of mobile applications, you can use a static dictionary directly in
+your settings file. Use ``APNS_CERTIFICATES`` and ``GCM_API_KEYS`` settings to store this dictionary for APNS and GCM
+correspondently. The ``APNS_CERTIFICATE`` and ``GCM_API_KEY`` settings are used as defaults.
+
+.. code-block:: python
+
+	PUSH_NOTIFICATIONS_SETTINGS = {
+		"GCM_API_KEY": "<your default application api key>",
+		"GCM_API_KEYS": {
+		    "<application ID 1>":"<your api key 1>",
+		    "<application ID 2>":"<your api key 2>",
+		    ...
+		},
+		"APNS_CERTIFICATE": "/path/to/your/default/certificate.pem",
+		"APNS_CERTIFICATES": {
+		    "<application ID 1>":"/path/to/your/certificate1.pem",
+		    "<application ID 2>":"/path/to/your/certificate2.pem",
+		    ...
+		}
+	}
+
+If your are planning to use dynamic and/or big number of mobile applications, you can use a dynamic access to
+the database table containig records describing applications. Use ``APNS_CERTIFICATES_MODEL``
+and ``GCM_API_KEYS_MODEL`` settings to describe model(s) containing reflection
+of application IDs to the correspondent values. The ``APNS_CERTIFICATE`` and ``GCM_API_KEY`` settings are used
+as defaults.
+
+Let say, the application ``applications`` contains a model ``ApplicationModel`` which contains three fields to
+reflect an application ID to the correspondent application credentials:
+
+.. code-block:: python
+
+    class ApplicationModel(models.Model):
+        application_id = models.CharField(max_length=64,db_index=True)
+        gcm_api_key = models.TextField()
+        apns_certificate = models.FileField()
+
+Then settings for the application should look like:
+
+.. code-block:: python
+
+	PUSH_NOTIFICATIONS_SETTINGS = {
+		"GCM_API_KEY": "<your default application api key>",
+		"GCM_API_KEYS_MODEL": {
+		    "model":"applications.ApplicationModel",
+		    "key":"application_id",
+		    "value":"gcm_api_key",
+		},
+		"APNS_CERTIFICATE": "/path/to/your/default/certificate.pem",
+		"APNS_CERTIFICATES_MODEL": {
+		    "model":"applications.ApplicationModel",
+		    "key":"application_id",
+		    "value":"apns_certificate",
+		}
+	}
+
+Definitely, either your mobile application should store it's application ID in the Device instance
+together with a registration ID while registering, or your server should identify the mobile
+application itself, while the mobile application instance is registering on the server.
+You can use application access token for the purpose in the latter case.
 
 Administration
 --------------

--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,8 @@ For APNS, you are required to include ``APNS_CERTIFICATE``, ``APNS_CERTIFICATES`
 - ``APNS_CA_CERTIFICATES``: Absolute path to a CA certificates file for APNS. Optional - do not set if not needed. Defaults to None.
 - ``GCM_API_KEY``: Your API key for GCM.
 - ``GCM_API_KEYS``: A dictionary reflecting separate application IDs to separate GCM API keys.
-- ``GCM_API_KEYS_MODEL``: A dictionary reflecting separate application IDs to separate GCM API
-  keys.
+- ``GCM_API_KEYS_MODEL``: A dictionary containing description of a database model to reflect application IDs to
+  GCM API keys.
     - ``'model'`` - a model name like ``'my_application.MyModel'``
     - ``'key'`` - a field name of the model referenced above, containing an application ID like ``'application_id'``
     - ``'value'`` - a path to the field from the model referenced above, which contains a GCM API key like ``'api_key'``
@@ -172,9 +172,9 @@ reflect an application ID to the correspondent application credentials:
 .. code-block:: python
 
     class ApplicationModel(models.Model):
-        application_id = models.CharField(max_length=64,db_index=True)
-        gcm_api_key = models.TextField()
-        apns_certificate = models.FileField()
+        application_id = models.CharField(max_length=64,unique=True)
+        gcm_api_key = models.TextField(null=True,blank=True)
+        apns_certificate = models.FileField(null=True,blank=True)
 
 Then settings for the application should look like:
 
@@ -197,7 +197,7 @@ Then settings for the application should look like:
 
 Definitely, either your mobile application should store it's application ID in the Device instance
 together with a registration ID while registering, or your server should identify the mobile
-application itself, while the mobile application instance is registering on the server.
+application, while the mobile application instance is registering itself on the server.
 You can use application access token for the purpose in the latter case.
 
 Administration

--- a/push_notifications/admin.py
+++ b/push_notifications/admin.py
@@ -50,12 +50,10 @@ class DeviceAdmin(admin.ModelAdmin):
 		# if the user doesn't select all the devices for pruning, we
 		# could very easily leave an expired device as active.  Maybe
 		#  this is just a bad API.
-		expired = get_expired_tokens()
-		devices = queryset.filter(registration_id__in=expired)
-		for d in devices:
-			d.active = False
-			d.save()
-
+		app_ids = set(queryset.values_list('application_id', flat=True).distinct())
+		for app_id in app_ids:
+			expired = get_expired_tokens(app_id)
+			queryset.filter(registration_id__in=expired).update(active=False)
 
 admin.site.register(APNSDevice, DeviceAdmin)
 admin.site.register(GCMDevice, DeviceAdmin)

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -4,7 +4,7 @@ from rest_framework import permissions
 from rest_framework.serializers import ModelSerializer, ValidationError
 from rest_framework.validators import UniqueValidator
 from rest_framework.viewsets import ModelViewSet
-from rest_framework.fields import IntegerField
+from rest_framework.fields import IntegerField, UUIDField
 
 from push_notifications.models import APNSDevice, GCMDevice
 from push_notifications.fields import hex_re
@@ -34,7 +34,7 @@ class HexIntegerField(IntegerField):
 # Serializers
 class DeviceSerializerMixin(ModelSerializer):
 	class Meta:
-		fields = ("name", "registration_id", "device_id", "active", "date_created")
+		fields = ("name", "application_id", "registration_id", "device_id", "active", "date_created")
 		read_only_fields = ("date_created", )
 
 		# See https://github.com/tomchristie/django-rest-framework/issues/1101
@@ -42,6 +42,11 @@ class DeviceSerializerMixin(ModelSerializer):
 
 
 class APNSDeviceSerializer(ModelSerializer):
+	device_id = UUIDField(
+		help_text="UDID / UIDevice.identifierForVendor() (e.g. 5ce0e9a5-5ffa-654b-cee0-1238041fb31a)",
+		style={'input_type': 'text'},
+		required=False
+	)
 
 	class Meta(DeviceSerializerMixin.Meta):
 		model = APNSDevice

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -15,6 +15,7 @@ from binascii import unhexlify
 from django.core.exceptions import ImproperlyConfigured
 from . import NotificationError
 from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+from .dynamic import get_apns_certificate
 
 
 class APNSError(NotificationError):
@@ -32,8 +33,8 @@ class APNSDataOverflow(APNSError):
 	pass
 
 
-def _apns_create_socket(address_tuple):
-	certfile = SETTINGS.get("APNS_CERTIFICATE")
+def _apns_create_socket(address_tuple, application_id):
+	certfile = get_apns_certificate(application_id)
 	if not certfile:
 		raise ImproperlyConfigured(
 			'You need to set PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] to send messages through APNS.'
@@ -54,12 +55,12 @@ def _apns_create_socket(address_tuple):
 	return sock
 
 
-def _apns_create_socket_to_push():
-	return _apns_create_socket((SETTINGS["APNS_HOST"], SETTINGS["APNS_PORT"]))
+def _apns_create_socket_to_push(application_id):
+	return _apns_create_socket((SETTINGS["APNS_HOST"], SETTINGS["APNS_PORT"]), application_id)
 
 
-def _apns_create_socket_to_feedback():
-	return _apns_create_socket((SETTINGS["APNS_FEEDBACK_HOST"], SETTINGS["APNS_FEEDBACK_PORT"]))
+def _apns_create_socket_to_feedback(application_id):
+	return _apns_create_socket((SETTINGS["APNS_FEEDBACK_HOST"], SETTINGS["APNS_FEEDBACK_PORT"]), application_id)
 
 
 def _apns_pack_frame(token_hex, payload, identifier, expiration, priority):
@@ -102,7 +103,7 @@ def _apns_check_errors(sock):
 		sock.settimeout(saved_timeout)
 
 
-def _apns_send(token, alert, badge=None, sound=None, category=None, content_available=False,
+def _apns_send(token, alert, application_id, badge=None, sound=None, category=None, content_available=False,
 	action_loc_key=None, loc_key=None, loc_args=[], extra={}, identifier=0,
 	expiration=None, priority=10, socket=None):
 	data = {}
@@ -150,7 +151,7 @@ def _apns_send(token, alert, badge=None, sound=None, category=None, content_avai
 	if socket:
 		socket.write(frame)
 	else:
-		with closing(_apns_create_socket_to_push()) as socket:
+		with closing(_apns_create_socket_to_push(application_id)) as socket:
 			socket.write(frame)
 			_apns_check_errors(socket)
 
@@ -194,7 +195,7 @@ def _apns_receive_feedback(socket):
 	return expired_token_list
 
 
-def apns_send_message(registration_id, alert, **kwargs):
+def apns_send_message(registration_id, alert, application_id, **kwargs):
 	"""
 	Sends an APNS notification to a single registration_id.
 	This will send the notification as form data.
@@ -206,10 +207,10 @@ def apns_send_message(registration_id, alert, **kwargs):
 	to this for silent notifications.
 	"""
 
-	_apns_send(registration_id, alert, **kwargs)
+	_apns_send(registration_id, alert, application_id, **kwargs)
 
 
-def apns_send_bulk_message(registration_ids, alert, **kwargs):
+def apns_send_bulk_message(registration_ids, alert, application_id, **kwargs):
 	"""
 	Sends an APNS notification to one or more registration_ids.
 	The registration_ids argument needs to be a list.
@@ -218,18 +219,18 @@ def apns_send_bulk_message(registration_ids, alert, **kwargs):
 	it won't be included in the notification. You will need to pass None
 	to this for silent notifications.
 	"""
-	with closing(_apns_create_socket_to_push()) as socket:
+	with closing(_apns_create_socket_to_push(application_id)) as socket:
 		for identifier, registration_id in enumerate(registration_ids):
-			_apns_send(registration_id, alert, identifier=identifier, socket=socket, **kwargs)
+			_apns_send(registration_id, alert, application_id, identifier=identifier, socket=socket, **kwargs)
 		_apns_check_errors(socket)
 
 
-def apns_fetch_inactive_ids():
+def apns_fetch_inactive_ids(application_id):
 	"""
 	Queries the APNS server for id's that are no longer active since
 	the last fetch
 	"""
-	with closing(_apns_create_socket_to_feedback()) as socket:
+	with closing(_apns_create_socket_to_feedback(application_id)) as socket:
 		inactive_ids = []
 		# Maybe we should have a flag to return the timestamp?
 		# It doesn't seem that useful right now, though.

--- a/push_notifications/dynamic.py
+++ b/push_notifications/dynamic.py
@@ -1,0 +1,59 @@
+from django.core.exceptions import ImproperlyConfigured
+from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+from .modeldict import FieldPairDict
+
+try:
+	basestring
+except:
+	basestring = str
+
+
+def _get_application_settings(application_id, settings_key, error_message):
+	if not application_id:  # old behaviour
+		value = SETTINGS.get(settings_key, None)
+		if not value:
+			raise ImproperlyConfigured(error_message)
+		return value
+	# new behaviour, settings dict
+	values = SETTINGS.get(settings_key + "S", {})
+
+	if application_id in values:
+		value = values.get(application_id)
+		if value is not None:
+			return value
+
+	# new behaviour, getting from the model
+	values_model = SETTINGS.get(settings_key + "S_MODEL", None)
+	if values_model:
+		model = values_model.get('model', None)
+		key = values_model.get('key', None)
+		value = values_model.get('value', None)
+		if model and key and value:
+			values = FieldPairDict(model, key, value)
+
+	if application_id in values:
+		value = values.get(application_id)
+		if value is not None:
+			return value
+
+	value = SETTINGS.get(settings_key, None)
+	if not value:
+		raise ImproperlyConfigured(error_message)
+	return value
+
+
+def get_gcm_api_key(application_id=None):
+	return _get_application_settings(application_id, "GCM_API_KEY", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_apns_certificate(application_id=None):
+	r = _get_application_settings(application_id, "APNS_CERTIFICATE", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+	if not isinstance(r, basestring):
+		# probably the (Django) file, and file path should be got
+		if hasattr(r, 'path'):
+			return r.path
+		elif (hasattr(r, 'has_key') or hasattr(r, '__contains__')) and 'path' in r:
+			return r['path']
+		else:
+			raise ImproperlyConfigured("The APNS certificate settings value should be a string, or should have a 'path' attribute or key")
+	return r

--- a/push_notifications/management/commands/prune_devices.py
+++ b/push_notifications/management/commands/prune_devices.py
@@ -7,10 +7,8 @@ class Command(BaseCommand):
 
 	def handle(self, *args, **options):
 		from push_notifications.models import APNSDevice, get_expired_tokens
-		expired = get_expired_tokens()
-		devices = APNSDevice.objects.filter(registration_id__in=expired)
-		for d in devices:
-			self.stdout.write('deactivating [%s]' % d.registration_id)
-			d.active = False
-			d.save()
-		self.stdout.write('deactivated %d devices' % len(devices))
+		app_ids = set(APNSDevice.objects.values_list('application_id', flat=True).distinct())
+		for app_id in app_ids:
+			expired = get_expired_tokens(app_id)
+			cnt = APNSDevice.objects.filter(registration_id__in=expired).update(active=False)
+			self.stdout.write('deactivated %d devices' % cnt)

--- a/push_notifications/migrations/0001_initial.py
+++ b/push_notifications/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.conf import settings
 
 try:
     from django.db.models import UUIDField
-except:
+except ImportError:
     from uuidfield import UUIDField
 
 

--- a/push_notifications/migrations/0001_initial.py
+++ b/push_notifications/migrations/0001_initial.py
@@ -5,6 +5,11 @@ from django.db import models, migrations
 import push_notifications.fields
 from django.conf import settings
 
+try:
+    from django.db.models import UUIDField
+except:
+    from uuidfield import UUIDField
+
 
 class Migration(migrations.Migration):
 
@@ -20,7 +25,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=255, null=True, verbose_name='Name', blank=True)),
                 ('active', models.BooleanField(default=True, help_text='Inactive devices will not be sent notifications', verbose_name='Is active')),
                 ('date_created', models.DateTimeField(auto_now_add=True, verbose_name='Creation date', null=True)),
-                ('device_id', models.UUIDField(help_text=b'UDID / UIDevice.identifierForVendor()', max_length=32, null=True, verbose_name='Device ID', blank=True, db_index=True)),
+                ('device_id', UUIDField(help_text=b'UDID / UIDevice.identifierForVendor()', max_length=32, null=True, verbose_name='Device ID', blank=True, db_index=True)),
                 ('registration_id', models.CharField(unique=True, max_length=64, verbose_name='Registration ID')),
                 ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
             ],

--- a/push_notifications/migrations/0002_auto_20151125_1555.py
+++ b/push_notifications/migrations/0002_auto_20151125_1555.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_notifications', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='apnsdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='gcmdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/push_notifications/migrations/0003_applicationmodel.py
+++ b/push_notifications/migrations/0003_applicationmodel.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_notifications', '0002_auto_20151125_1555'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ApplicationModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('application_id', models.CharField(unique=True, max_length=64, verbose_name='Application ID')),
+                ('gcm_api_key', models.TextField(null=True, verbose_name='GCM API Key', blank=True)),
+                ('apns_certificate', models.FileField(upload_to='apns_certificates', null=True, verbose_name='APNS Certificate', blank=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/push_notifications/modeldict.py
+++ b/push_notifications/modeldict.py
@@ -1,0 +1,99 @@
+from django.apps import apps
+from collections import MutableMapping
+
+try:
+	basestring
+except:
+	basestring = str
+
+
+class ModelDict(MutableMapping):
+	def __init__(self, model, key_field):
+		self._model = model
+		self._key = key_field
+
+	def _fix_model(self):
+		if isinstance(self._model, basestring):
+			self._model = apps.get_model(*self._model.split('.', 1))
+
+	def _get_value(self, o):
+		return {f.name: getattr(o, f.name) for f in o._meta.fields}
+
+	def _set_value(self, o, value):
+		for k in value:
+			# some inconsistency with natural dict: ignore absence instead of deleting;
+			# use None to clean the field value instead
+			setattr(o, k, value[k])
+		o.save()
+
+	def get(self, key, *d):
+		self._fix_model()
+		q = self._model.objects.filter(**{self._key: key})
+		if q:
+			return self._get_value(q[0])
+		if len(d):
+			return d[0]
+		raise KeyError("No such key in the database")
+
+	def has_key(self, key):
+		self._fix_model()
+		q = self._model.objects.filter(**{self._key: key})
+		return bool(q)
+
+	def set(self, key, value):
+		self._fix_model()
+		q = self._model.objects.filter(**{self._key: key})
+		if q:
+			o = q[0]
+		else:
+			o = self._model(**{self._key: key})
+		self._set_value(o, value)
+
+	def remove(self, key):
+		self._fix_model()
+		self._model.objects.filter(**{self._key: key}).delete()
+
+	def __getitem__(self, key):
+		return self.get(key)
+
+	def __setitem__(self, key, value):
+		return self.set(key, value)
+
+	def __delitem__(self, key):
+		return self.remove(key)
+
+	def __iter__(self):
+		self._fix_model()
+		for o in self._model.objects.all():
+			yield getattr(o, self._key)
+
+	def __len__(self):
+		self._fix_model()
+		return self._model.objects.count()
+
+
+class FieldPairDict(ModelDict):
+	def __init__(self, model, key_field, value_field):
+		ModelDict.__init__(self, model, key_field)
+		self._value = value_field
+		if '.' in self._value:
+			self._value = self._value.split('.')
+		elif '__' in self._value:
+			self._value = self._value.split('__')
+		else:
+			self._value = [self._value]
+
+	def _get_value(self, o, path=None):
+		if path is None:
+			path = self._value
+		v = ModelDict._get_value(self, o)[path[0]]
+		path = path[1:]
+		if not path:
+			return v
+		return self._get_value(v, path)
+
+	def _set_value(self, o, value):
+		if len(self._value) > 1:
+			raise AttributeError("Dict assignment over relations is ambiguous")
+		setattr(o, self._value[0], value)
+		o.save()

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -9,8 +9,9 @@ from .fields import HexIntegerField
 
 try:
 	from django.db.models import UUIDField
-except:
+except ImportError:
 	from uuidfield import UUIDField
+
 
 @python_2_unicode_compatible
 class Device(models.Model):
@@ -19,6 +20,9 @@ class Device(models.Model):
 		help_text=_("Inactive devices will not be sent notifications"))
 	user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
 	date_created = models.DateTimeField(verbose_name=_("Creation date"), auto_now_add=True, null=True)
+	application_id = models.CharField(max_length=64, verbose_name=_("Application ID"),
+		help_text=_("Opaque application identity, should be filled in for multiple key/certificate access"),
+		blank=True, null=True)
 
 	class Meta:
 		abstract = True
@@ -43,8 +47,15 @@ class GCMDeviceQuerySet(models.query.QuerySet):
 			if message is not None:
 				data["message"] = message
 
-			reg_ids = list(self.filter(active=True).values_list('registration_id', flat=True))
-			return gcm_send_bulk_message(registration_ids=reg_ids, data=data, **kwargs)
+			app_ids = set(self.filter(active=True).values_list('application_id', flat=True).distinct())
+			res = []
+			for app_id in app_ids:
+				reg_ids = list(self.filter(active=True, application_id=app_id).values_list('registration_id', flat=True))
+				r = gcm_send_bulk_message(registration_ids=reg_ids, data=data, application_id=app_id, **kwargs)
+				if hasattr(r, 'keys'):
+					res += [r]
+				elif hasattr(r, '__getitem__'):
+					res += r
 
 
 class GCMDevice(Device):
@@ -65,7 +76,7 @@ class GCMDevice(Device):
 		data = kwargs.pop("extra", {})
 		if message is not None:
 			data["message"] = message
-		return gcm_send_message(registration_id=self.registration_id, data=data, **kwargs)
+		return gcm_send_message(registration_id=self.registration_id, data=data, application_id=self.application_id, **kwargs)
 
 
 class APNSDeviceManager(models.Manager):
@@ -77,8 +88,17 @@ class APNSDeviceQuerySet(models.query.QuerySet):
 	def send_message(self, message, **kwargs):
 		if self:
 			from .apns import apns_send_bulk_message
-			reg_ids = list(self.filter(active=True).values_list('registration_id', flat=True))
-			return apns_send_bulk_message(registration_ids=reg_ids, alert=message, **kwargs)
+
+			app_ids = set(self.filter(active=True).values_list('application_id', flat=True).distinct())
+			res = []
+			for app_id in app_ids:
+				reg_ids = list(self.filter(active=True, application_id=app_id).values_list('registration_id', flat=True))
+				r = apns_send_bulk_message(registration_ids=reg_ids, alert=message, application_id=app_id, **kwargs)
+				if hasattr(r, 'keys'):
+					res += [r]
+				elif hasattr(r, '__getitem__'):
+					res += r
+			return res
 
 
 class APNSDevice(Device):
@@ -94,11 +114,17 @@ class APNSDevice(Device):
 	def send_message(self, message, **kwargs):
 		from .apns import apns_send_message
 
-		return apns_send_message(registration_id=self.registration_id, alert=message, **kwargs)
+		return apns_send_message(registration_id=self.registration_id, alert=message, application_id=self.application_id, **kwargs)
 
 
 # This is an APNS-only function right now, but maybe GCM will implement it
 # in the future.  But the definition of 'expired' may not be the same. Whatevs
-def get_expired_tokens():
+def get_expired_tokens(application_id):
 	from .apns import apns_fetch_inactive_ids
-	return apns_fetch_inactive_ids()
+	return apns_fetch_inactive_ids(application_id)
+
+
+class ApplicationModel(models.Model):
+	application_id = models.CharField(max_length=64, verbose_name=_("Application ID"), unique=True)
+	gcm_api_key = models.TextField(verbose_name=_("GCM API Key"), null=True, blank=True)
+	apns_certificate = models.FileField(verbose_name=_("APNS Certificate"), null=True, blank=True, upload_to='apns_certificates')

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -3,6 +3,10 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from .fields import HexIntegerField
 
+try:
+	from django.db.models import UUIDField
+except:
+	from uuidfield import UUIDField
 
 class Device(models.Model):
 	name = models.CharField(max_length=255, verbose_name=_("Name"), blank=True, null=True)
@@ -73,7 +77,7 @@ class APNSDeviceQuerySet(models.query.QuerySet):
 
 
 class APNSDevice(Device):
-	device_id = models.UUIDField(verbose_name=_("Device ID"), blank=True, null=True, db_index=True,
+	device_id = UUIDField(verbose_name=_("Device ID"), blank=True, null=True, db_index=True,
 		help_text="UDID / UIDevice.identifierForVendor()")
 	registration_id = models.CharField(verbose_name=_("Registration ID"), max_length=64, unique=True)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,8 @@ from test_models import *
 from test_gcm_push_payload import *
 from test_apns_push_payload import *
 from test_management_commands import *
+from test_modeldict import *
+from test_dynamic_settings import *
 
 # conditionally test rest_framework api if the DRF package is installed
 try:

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -1,10 +1,16 @@
 GCM_PLAIN_RESPONSE = 'id=1:08'
 GCM_JSON_RESPONSE = '{"multicast_id":108,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:08"}]}'
-GCM_MULTIPLE_JSON_RESPONSE = '{"multicast_id":108,"success":2,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:08"}, {"message_id": "1:09"}]}'
+GCM_MULTIPLE_JSON_RESPONSE = ('{"multicast_id":108,"success":2,"failure":0,"canonical_ids":0,"results":'
+							  '[{"message_id":"1:08"}, {"message_id": "1:09"}]}')
 GCM_PLAIN_RESPONSE_ERROR = ['Error=NotRegistered', 'Error=InvalidRegistration']
 GCM_PLAIN_RESPONSE_ERROR_B = 'Error=MismatchSenderId'
 GCM_PLAIN_CANONICAL_ID_RESPONSE = "id=1:2342\nregistration_id=NEW_REGISTRATION_ID"
-GCM_JSON_RESPONSE_ERROR = '{"failure": 3, "canonical_ids": 0, "cast_id": 6358665107659088804, "results": [{"error": "NotRegistered"}, {"message_id": "0:1433830664381654%3449593ff9fd7ecd"}, {"error": "InvalidRegistration"}]}'
+GCM_JSON_RESPONSE_ERROR = ('{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, "results":'
+						   ' [{"error": "NotRegistered"}, {"message_id": "0:1433830664381654%3449593ff9fd7ecd"}, '
+						   '{"error": "InvalidRegistration"}]}')
+GCM_JSON_RESPONSE_ERROR_B = ('{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, '
+							 '"results": [{"error": "MismatchSenderId"}, {"message_id": '
+							 '"0:1433830664381654%3449593ff9fd7ecd"}, {"error": "InvalidRegistration"}]}')
 GCM_DRF_INVALID_HEX_ERROR = {'device_id': [u"ValidationError Device ID is not a valid hex number"]}
 GCM_DRF_OUT_OF_RANGE_ERROR = {'device_id': [u"ValidationError Device ID is out of range"]}
 GCM_JSON_CANONICAL_ID_RESPONSE = '{"failure":0,"canonical_ids":1,"success":2,"multicast_id":7173139966327257000,"results":[{"registration_id":"NEW_REGISTRATION_ID","message_id":"0:1440068396670935%6868637df9fd7ecd"},{"message_id":"0:1440068396670937%6868637df9fd7ecd"}]}'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -21,3 +21,10 @@ SITE_ID = 1
 ROOT_URLCONF = "core.urls"
 
 SECRET_KEY = "foobar"
+
+PUSH_NOTIFICATIONS_SETTINGS = {}
+
+import os
+
+ROOT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+MEDIA_ROOT = os.path.join(ROOT_DIR,"testmedia")

--- a/tests/test_apns_push_payload.py
+++ b/tests/test_apns_push_payload.py
@@ -2,30 +2,65 @@ import mock
 from django.test import TestCase
 from push_notifications.apns import _apns_send, APNSDataOverflow
 
+from django.conf import settings
+from push_notifications.models import ApplicationModel
 
 class APNSPushPayloadTest(TestCase):
 	def test_push_payload(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			_apns_send("123", "Hello world",
+			_apns_send("123", "Hello world", None,
 				badge=1, sound="chime", extra={"custom_data": 12345}, expiration=3, socket=socket)
 			p.assert_called_once_with("123",
 				b'{"aps":{"alert":"Hello world","badge":1,"sound":"chime"},"custom_data":12345}', 0, 3, 10)
 
+
 	def test_localised_push_with_empty_body(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			_apns_send("123", None, loc_key="TEST_LOC_KEY", expiration=3, socket=socket)
+			_apns_send("123", None, None, loc_key="TEST_LOC_KEY", expiration=3, socket=socket)
 			p.assert_called_once_with("123", b'{"aps":{"alert":{"loc-key":"TEST_LOC_KEY"}}}', 0, 3, 10)
 
 	def test_using_extra(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			_apns_send("123", "sample", extra={"foo": "bar"}, identifier=10, expiration=30, priority=10, socket=socket)
+			_apns_send("123", "sample", None, extra={"foo": "bar"}, identifier=10, expiration=30, priority=10, socket=socket)
 			p.assert_called_once_with("123", b'{"aps":{"alert":"sample"},"foo":"bar"}', 10, 30, 10)
 
 	def test_oversized_payload(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			self.assertRaises(APNSDataOverflow, _apns_send, "123", "_" * 2049, socket=socket)
+			self.assertRaises(APNSDataOverflow, _apns_send, "123", "_" * 2049, None, socket=socket)
 			p.assert_has_calls([])
+
+class APNSPushSettingsTest(TestCase):
+	def test_push_payload_with_app_id(self):
+		settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES_MODEL'] = {
+		    'model':'push_notifications.ApplicationModel',
+		    'key':'application_id',
+		    'value':'apns_certificate',
+		}
+		import ssl
+		from django.core.files.base import ContentFile
+		f = ContentFile("QWERTY!!!")
+		a = ApplicationModel.objects.create(application_id='qwertyxxx')
+		a.apns_certificate.save("uiopcertxxx",f)
+		path = a.apns_certificate.path
+		socket = mock.MagicMock()
+		with mock.patch("ssl.wrap_socket",return_value=socket) as s:
+			with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+				_apns_send("123", "Hello world", 'qwertyxxx',
+					badge=1, sound="chime", extra={"custom_data": 12345}, expiration=3)
+				s.assert_called_once_with(*s.call_args[0],ca_certs=None,certfile=path,ssl_version=ssl.PROTOCOL_TLSv1)
+				p.assert_called_once_with("123",
+					b'{"aps":{"alert":"Hello world","badge":1,"sound":"chime"},"custom_data":12345}', 0, 3, 10)
+	def tearDown(self):
+	    # teardown temporary media
+	    from django.conf import settings
+	    import os
+	    for root, dirs, files in os.walk(settings.MEDIA_ROOT, topdown=False):
+	        for name in files:
+	            os.remove(os.path.join(root, name))
+	        for name in dirs:
+	            os.rmdir(os.path.join(root, name))
+	    os.removedirs(settings.MEDIA_ROOT)

--- a/tests/test_dynamic_settings.py
+++ b/tests/test_dynamic_settings.py
@@ -1,0 +1,76 @@
+import json
+import mock
+from django.test import TestCase
+from django.utils import timezone
+from push_notifications import dynamic
+from django.conf import settings
+
+from django.core.exceptions import ImproperlyConfigured
+
+from push_notifications.models import ApplicationModel
+
+class DynamicSettingsTestCase(TestCase):
+    def test_base_settings(self):
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TEST'] = 'test'
+        assert dynamic._get_application_settings('qwerty','TEST','Test Exception') == 'test'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TESTS'] = {
+            'qwerty':'uiop'
+        }
+        assert dynamic._get_application_settings('qwerty','TEST','Test Exception') == 'uiop'
+        assert dynamic._get_application_settings('uiop','TEST','Test Exception') == 'test'
+        try:
+            dynamic._get_application_settings('qwerty','NOTPRESENT','Test Exception')
+            assert False
+        except Exception as ex:
+            assert type(ex) == ImproperlyConfigured
+            assert ex.args and ex.args[0] == 'Test Exception'
+
+    def test_default_if_none(self):
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TEST'] = 'test'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TESTS'] = {
+            'qwerty':'uiop',
+            'qwerty2':None
+        }
+        assert dynamic._get_application_settings('qwerty','TEST','Test Exception') == 'uiop'
+        assert dynamic._get_application_settings('qwerty2','TEST','Test Exception') == 'test'
+
+    def test_database_settings(self):
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TEST'] = 'test'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TESTS_MODEL'] = {
+            'model':'push_notifications.ApplicationModel',
+            'key':'application_id',
+            'value':'gcm_api_key',
+        }
+        ApplicationModel.objects.create(application_id='qwerty2',gcm_api_key='uiop2')
+        assert dynamic._get_application_settings('qwerty2','TEST','Test Exception') == 'uiop2'
+        assert dynamic._get_application_settings('uiop2','TEST','Test Exception') == 'test'
+        try:
+            dynamic._get_application_settings('qwerty','NOTPRESENT','Test Exception')
+            assert False
+        except Exception as ex:
+            assert type(ex) == ImproperlyConfigured
+            assert ex.args and ex.args[0] == 'Test Exception'
+
+    def test_push_settings(self):
+        try:
+            r = dynamic.get_gcm_api_key()
+            assert False
+        except Exception as ex:
+            assert type(ex) == ImproperlyConfigured
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEY'] = 'testkey'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATE'] = 'testcert'
+        assert dynamic.get_gcm_api_key() == 'testkey'
+        assert dynamic.get_apns_certificate() == 'testcert'
+
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'qwerty':'uiopkey'
+        }
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES'] = {
+            'qwerty':'uiopcert'
+        }
+        assert dynamic.get_gcm_api_key() == 'testkey'
+        assert dynamic.get_apns_certificate() == 'testcert'
+        assert dynamic.get_gcm_api_key('uiop') == 'testkey'
+        assert dynamic.get_apns_certificate('uiop') == 'testcert'
+        assert dynamic.get_gcm_api_key('qwerty') == 'uiopkey'
+        assert dynamic.get_apns_certificate('qwerty') == 'uiopcert'

--- a/tests/test_gcm_push_payload.py
+++ b/tests/test_gcm_push_payload.py
@@ -11,18 +11,35 @@ class GCMPushPayloadTest(TestCase):
 			gcm_send_message("abc", {"message": "Hello world"})
 			p.assert_called_once_with(
 				b"data.message=Hello+world&registration_id=abc",
-				"application/x-www-form-urlencoded;charset=UTF-8")
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				None)
+
+	def test_push_payload_with_app_id(self):
+		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+			gcm_send_message("abc", {"message": "Hello world"}, 'qwerty')
+			p.assert_called_once_with(
+				b"data.message=Hello+world&registration_id=abc",
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				'qwerty')
+		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+			gcm_send_message("abc", {"message": "Hello world"}, application_id='qwerty')
+			p.assert_called_once_with(
+				b"data.message=Hello+world&registration_id=abc",
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				'qwerty')
 
 	def test_push_payload_params(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
 			gcm_send_message("abc", {"message": "Hello world"}, delay_while_idle=True, time_to_live=3600)
 			p.assert_called_once_with(
 				b"data.message=Hello+world&delay_while_idle=1&registration_id=abc&time_to_live=3600",
-				"application/x-www-form-urlencoded;charset=UTF-8")
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				None)
 
 	def test_bulk_push_payload(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON_RESPONSE) as p:
 			gcm_send_bulk_message(["abc", "123"], {"message": "Hello world"})
 			p.assert_called_once_with(
 				b'{"data":{"message":"Hello world"},"registration_ids":["abc","123"]}',
-				"application/json")
+				"application/json",
+				None)

--- a/tests/test_modeldict.py
+++ b/tests/test_modeldict.py
@@ -1,0 +1,45 @@
+import json
+import mock
+from django.test import TestCase
+from django.utils import timezone
+from django.contrib.auth.models import User
+from push_notifications import modeldict
+
+class ModelDictTestCase(TestCase):
+    def test_model_dict_simple_cases(self):
+        for k in (1,2,3,4,5):
+            user = User.objects.create(
+                username = 'u%s' % k,
+                first_name= "user u%s" % k
+            )
+        md = modeldict.ModelDict('auth.User','username')
+        keys = list(md.keys())
+        keys.sort()
+        assert tuple(keys) == ('u1','u2','u3','u4','u5')
+        assert 'u2' in md
+        assert 'uu2' not in md
+        for k in keys:
+            assert md[k]['first_name'] == "user %s" % k
+        for k in keys:
+            md[k] = {"last_name":"user last name %s" % k}
+        for k in keys:
+            assert md[k]['last_name'] == "user last name %s" % k
+        assert md.get('notpresent','default') == 'default'
+
+    def test_field_pair_dict_simple_cases(self):
+        for k in (1,2,3,4,5):
+            user = User.objects.create(
+                username = 'u%s' % k,
+                first_name= "user u%s" % k
+            )
+        md = modeldict.FieldPairDict('auth.User','username','first_name')
+        keys = list(md.keys())
+        keys.sort()
+        assert tuple(keys) == ('u1','u2','u3','u4','u5')
+        for k in keys:
+            assert md[k] == "user %s" % k
+        for k in keys:
+            md[k] = "user last name %s" % k
+        for k in keys:
+            assert md[k] == "user last name %s" % k
+        assert md.get('notpresent','default') == 'default'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,6 @@ from tests.mock_responses import GCM_PLAIN_RESPONSE, \
     GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE
 from push_notifications.gcm import GCMError
 
-
 class ModelTestCase(TestCase):
     def test_can_save_gcm_device(self):
         device = GCMDevice.objects.create(
@@ -36,7 +35,20 @@ class ModelTestCase(TestCase):
             device.send_message("Hello world")
             p.assert_called_once_with(
                 b"data.message=Hello+world&registration_id=abc",
-                "application/x-www-form-urlencoded;charset=UTF-8")
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None)
+
+    def test_gcm_send_message_with_app_id(self):
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="qwerty",
+        )
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+            device.send_message("Hello world")
+            p.assert_called_once_with(
+                b"data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                "qwerty")
 
     def test_gcm_send_message_extra(self):
         device = GCMDevice.objects.create(
@@ -46,7 +58,8 @@ class ModelTestCase(TestCase):
             device.send_message("Hello world", extra={"foo": "bar"})
             p.assert_called_once_with(
                 b"data.foo=bar&data.message=Hello+world&registration_id=abc",
-                "application/x-www-form-urlencoded;charset=UTF-8")
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None)
 
     def test_gcm_send_message_collapse_key(self):
         device = GCMDevice.objects.create(
@@ -56,7 +69,8 @@ class ModelTestCase(TestCase):
             device.send_message("Hello world", collapse_key="test_key")
             p.assert_called_once_with(
                 b"collapse_key=test_key&data.message=Hello+world&registration_id=abc",
-                "application/x-www-form-urlencoded;charset=UTF-8")
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None)
 
     def test_gcm_send_message_to_multiple_devices(self):
         GCMDevice.objects.create(
@@ -73,7 +87,7 @@ class ModelTestCase(TestCase):
                 json.dumps({
                     "data": { "message": "Hello world" },
                     "registration_ids": ["abc", "abc1"]
-                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
     def test_gcm_send_message_active_devices(self):
         GCMDevice.objects.create(
@@ -92,7 +106,7 @@ class ModelTestCase(TestCase):
                 json.dumps({
                     "data": { "message": "Hello world" },
                     "registration_ids": ["abc"]
-                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
     def test_gcm_send_message_extra_to_multiple_devices(self):
         GCMDevice.objects.create(
@@ -109,7 +123,7 @@ class ModelTestCase(TestCase):
                 json.dumps({
                     "data": { "foo": "bar", "message": "Hello world" },
                     "registration_ids": ["abc", "abc1"]
-                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
     def test_gcm_send_message_collapse_to_multiple_devices(self):
         GCMDevice.objects.create(
@@ -127,7 +141,7 @@ class ModelTestCase(TestCase):
                     "collapse_key": "test_key",
                     "data": { "message": "Hello world" },
                     "registration_ids": ["abc", "abc1"]
-                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
     def test_gcm_send_message_to_single_device_with_error(self):
         # these errors are device specific, device.active will be set false
@@ -210,6 +224,7 @@ class ModelTestCase(TestCase):
             device.send_message("Hello world", socket=socket, expiration=1)
             p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
 
+
     def test_apns_send_message_extra(self):
         device = APNSDevice.objects.create(
             registration_id="abc",
@@ -224,3 +239,131 @@ class ModelTestCase(TestCase):
             GCMDevice.objects.create(
                 registration_id=device,
             )
+
+class APNSModelWithSettingsTestCase(TestCase):
+    def test_apns_send_message_with_app_id(self):
+        from django.conf import settings
+        device = APNSDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES'] = {
+            'asdfg':'uiopcert'
+        }
+        f = open('uiopcert','wb')
+        f.write(b'')
+        f.close()
+        import ssl
+        socket = mock.MagicMock()
+        with mock.patch("ssl.wrap_socket",return_value=socket) as s:
+            with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+                device.send_message("Hello world", expiration=1)
+                p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+                s.assert_called_once_with(*s.call_args[0],ca_certs=None,certfile='uiopcert',ssl_version=ssl.PROTOCOL_TLSv1)
+
+    def test_apns_send_multi_message_with_app_id(self):
+        from django.conf import settings
+        device = APNSDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        device = APNSDevice.objects.create(
+            registration_id="def",
+            application_id="asdfg"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES'] = {
+            'asdfg':'uiopcert'
+        }
+        f = open('uiopcert','wb')
+        f.write(b'')
+        f.close()
+        import ssl
+        socket = mock.MagicMock()
+        with mock.patch("ssl.wrap_socket",return_value=socket) as s:
+            with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+                APNSDevice.objects.all().send_message("Hello world", expiration=1)
+                device.send_message("Hello world", expiration=1)
+                p.assert_any_call("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+                p.assert_any_call("def", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+                s.assert_any_call(*s.call_args_list[0][0],ca_certs=None,certfile='uiopcert',ssl_version=ssl.PROTOCOL_TLSv1)
+
+    def tearDown(self):
+        import os
+        os.unlink('uiopcert')
+
+class GCMModelWithSettingsTestCase(TestCase):
+    def test_gcm_send_message_with_app_id(self):
+        from django.conf import settings
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'asdfg':'uiopkey'
+        }
+        with mock.patch("push_notifications.gcm.urlopen") as u:
+            device.send_message("Hello world")
+            request = u.call_args[0][0]
+            assert request.headers['Authorization'] == 'key=uiopkey'
+
+    def test_gcm_send_multi_message_with_app_id(self):
+        from django.conf import settings
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        device = GCMDevice.objects.create(
+            registration_id="def",
+            application_id="asdfg"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'asdfg':'uiopkey'
+        }
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
+        import json
+        with mock.patch("push_notifications.gcm.urlopen",return_value=StringIO(json.dumps({
+            'failure':[],
+            'canonical_ids':[]
+        }))) as u:
+            GCMDevice.objects.all().send_message("Hello world")
+            assert u.call_count == 1
+            request = u.call_args[0][0]
+            assert request.headers['Authorization'] == 'key=uiopkey'
+
+    def test_gcm_send_multi_message_with_different_app_id(self):
+        from django.conf import settings
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        device = GCMDevice.objects.create(
+            registration_id="def",
+            application_id="uiop"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'asdfg':'asdfgkey',
+            'uiop':'uiopkey'
+        }
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
+        import json
+        requests = []
+        def c():
+            def f(r):
+                requests.append(r)
+                return StringIO(json.dumps({
+                    'failure':[],
+                    'canonical_ids':[]
+                }))
+            return f
+        with mock.patch("push_notifications.gcm.urlopen",new_callable=c) as u:
+            GCMDevice.objects.all().send_message("Hello world")
+            keys = set(r.headers['Authorization'] for r in requests)
+            assert len(keys) == 2
+            assert 'key=asdfgkey' in keys
+            assert 'key=uiopkey' in keys

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,11 +3,10 @@ import mock
 from django.test import TestCase
 from django.utils import timezone
 from push_notifications.models import GCMDevice, APNSDevice
-from tests.mock_responses import GCM_PLAIN_RESPONSE, \
-    GCM_MULTIPLE_JSON_RESPONSE, GCM_PLAIN_RESPONSE_ERROR, \
-    GCM_JSON_RESPONSE_ERROR, GCM_PLAIN_RESPONSE_ERROR_B,\
-    GCM_PLAIN_CANONICAL_ID_RESPONSE, GCM_JSON_CANONICAL_ID_RESPONSE,\
-    GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE
+from tests.mock_responses import ( GCM_PLAIN_RESPONSE,GCM_MULTIPLE_JSON_RESPONSE, GCM_PLAIN_RESPONSE_ERROR,
+                                   GCM_JSON_RESPONSE_ERROR, GCM_PLAIN_RESPONSE_ERROR_B, GCM_JSON_RESPONSE_ERROR_B,
+                                   GCM_PLAIN_CANONICAL_ID_RESPONSE, GCM_JSON_CANONICAL_ID_RESPONSE,
+                                   GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE)
 from push_notifications.gcm import GCMError
 
 class ModelTestCase(TestCase):
@@ -153,8 +152,7 @@ class ModelTestCase(TestCase):
                 device = GCMDevice.objects. \
                     get(registration_id=device_list[index])
                 device.send_message("Hello World!")
-                assert GCMDevice.objects.get(registration_id=device_list[index]) \
-                           .active is False
+                assert GCMDevice.objects.get(registration_id=device_list[index]).active is False
 
     def test_gcm_send_message_to_single_device_with_error_b(self):
         # these errors are not device specific, GCMError should be thrown
@@ -166,8 +164,7 @@ class ModelTestCase(TestCase):
                 get(registration_id=device_list[0])
             with self.assertRaises(GCMError):
                 device.send_message("Hello World!")
-            assert GCMDevice.objects.get(registration_id=device_list[0]) \
-                            .active is True
+            assert GCMDevice.objects.get(registration_id=device_list[0]).active is True
 
     def test_gcm_send_message_to_multiple_devices_with_error(self):
         device_list = ['abc', 'abc1', 'abc2']
@@ -176,12 +173,21 @@ class ModelTestCase(TestCase):
                         return_value=GCM_JSON_RESPONSE_ERROR) as p:
             devices = GCMDevice.objects.all()
             devices.send_message("Hello World")
-            assert GCMDevice.objects.get(registration_id=device_list[0]) \
-                       .active is False
-            assert GCMDevice.objects.get(registration_id=device_list[1]) \
-                       .active is True
-            assert GCMDevice.objects.get(registration_id=device_list[2]) \
-                       .active is False
+            assert GCMDevice.objects.get(registration_id=device_list[0]).active is False
+            assert GCMDevice.objects.get(registration_id=device_list[1]).active is True
+            assert GCMDevice.objects.get(registration_id=device_list[2]).active is False
+
+    def test_gcm_send_message_to_multiple_devices_with_error_b(self):
+        device_list = ['abc', 'abc1', 'abc2']
+        self.create_devices(device_list)
+        with mock.patch("push_notifications.gcm._gcm_send",
+                        return_value=GCM_JSON_RESPONSE_ERROR_B) as p:
+            devices = GCMDevice.objects.all()
+            with self.assertRaises(GCMError):
+                devices.send_message("Hello World")
+            assert GCMDevice.objects.get(registration_id=device_list[0]).active is True
+            assert GCMDevice.objects.get(registration_id=device_list[1]).active is True
+            assert GCMDevice.objects.get(registration_id=device_list[2]).active is False
 
     def test_gcm_send_message_to_multiple_devices_with_canonical_id(self):
         device_list = ['foo', 'bar']

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -11,6 +11,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "AEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAE",
 			"name": "Apple iPhone 6+",
 			"device_id": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -19,6 +20,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "aeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeae",
 			"name": "Apple iPhone 6+",
 			"device_id": "ffffffffffffffffffffffffffffffff",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -27,6 +29,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "invalid device token contains no hex",
 			"name": "Apple iPhone 6+",
 			"device_id": "ffffffffffffffffffffffffffffake",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors["device_id"][0], '"ffffffffffffffffffffffffffffake" is not a valid UUID.')
@@ -39,6 +42,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -50,6 +54,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		serializer.is_valid(raise_exception=True)
 		obj = serializer.save()
@@ -59,6 +64,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 5",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		serializer.is_valid(raise_exception=True)
 		obj = serializer.save()
@@ -68,6 +74,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0xdeadbeaf",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 
 		with self.assertRaises(ValidationError) as ex:
@@ -79,6 +86,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x10r",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors, GCM_DRF_INVALID_HEX_ERROR)
@@ -88,6 +96,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "10000000000000000", # 2**64
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors, GCM_DRF_OUT_OF_RANGE_ERROR)
@@ -100,6 +109,6 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Nexus 5",
 			"device_id": "e87a4e72d634997c",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
-


### PR DESCRIPTION
This is a replacement for the pull request #247 with rearranged and partially squashed commits.

This patch extends the packet to support multiple mobile applications receiving push notifications from one server.

Code, documentation, and tests are provided.

The implementation is backward-compatible, so old-style using of the packet is still available.

Three types of settings are available:

- old-style - one mobile application per server instance, compatibility mode
- new-style static - multiple (several) mobile applications per server instance, settings file contains direct description of mobile applications credentials  (key/certificate), a new mobile application requires settings patching or reloading
- new-style dynamic - multiple (a lot) mobile applications per server instance, settings file contains reference to the custom model with mobile application credentials (key/certificate), a new mobile application can be created at runtime without server restart

This patch supercedes and dismisses (makes irrelevant) patch #226

This patch solves #130
