### PR TITLE
Clarify documentation around what APNS_HOST should be set as

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ For APNS, you are required to include ``APNS_CERTIFICATE``.
 - ``APNS_HOST``: The hostname used for the APNS sockets.
    - When ``DEBUG=True``, this defaults to ``gateway.sandbox.push.apple.com``.
    - When ``DEBUG=False``, this defaults to ``gateway.push.apple.com``.
+   - If you're running your app on a development device (i.e. not a build downloaded from the app store) you'll need to use the sandbox gateway regardless of whether DEBUG is True or False.
 - ``APNS_PORT``: The port used along with APNS_HOST. Defaults to 2195.
 - ``GCM_POST_URL``: The full url that GCM notifications will be POSTed to. Defaults to https://android.googleapis.com/gcm/send.
 - ``GCM_MAX_RECIPIENTS``: The maximum amount of recipients that can be contained per bulk message. If the ``registration_ids`` list is larger than that number, multiple bulk messages will be sent. Defaults to 1000 (the maximum amount supported by GCM).


### PR DESCRIPTION
I wasted a few minutes being confused about why push notifications were being delivered when my site was running locally but not when I deployed it to a staging server. It looks like the non-sandbox APNS gateway will only work with app store builds. Setting the gateway to the sandbox when in staging (even with DEBUG=False) got notifications delivering again for me. Hopefully this will save someone else some time in the future.