### PR TITLE
Update Device.user when updating existing devices via DRF.

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -103,7 +103,7 @@ class DeviceViewSetMixin(object):
 			serializer.save(user=self.request.user)
 		return super(DeviceViewSetMixin, self).perform_update(serializer)
 
-	
+
 class AuthorizedMixin(object):
 	permission_classes = (permissions.IsAuthenticated, IsOwner)
 

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -98,7 +98,12 @@ class DeviceViewSetMixin(object):
 			serializer.save(user=self.request.user)
 		return super(DeviceViewSetMixin, self).perform_create(serializer)
 
-
+	def perform_update(self, serializer):
+		if self.request.user.is_authenticated():
+			serializer.save(user=self.request.user)
+		return super(DeviceViewSetMixin, self).perform_update(serializer)
+		
+	
 class AuthorizedMixin(object):
 	permission_classes = (permissions.IsAuthenticated, IsOwner)
 

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -102,7 +102,7 @@ class DeviceViewSetMixin(object):
 		if self.request.user.is_authenticated():
 			serializer.save(user=self.request.user)
 		return super(DeviceViewSetMixin, self).perform_update(serializer)
-		
+
 	
 class AuthorizedMixin(object):
 	permission_classes = (permissions.IsAuthenticated, IsOwner)


### PR DESCRIPTION
Addresses issue #268 

Overrides `perform_update` (similar to `perform_create`) to update Device.user when updating existing devices. 