### PR TITLE
Fix bug when using gcm serializer as a nested serializer.

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from rest_framework import permissions
 from rest_framework.serializers import ModelSerializer, ValidationError
-from rest_framework.validators import UniqueValidator
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.fields import IntegerField
 
@@ -22,7 +21,7 @@ class HexIntegerField(IntegerField):
 		# validate hex string and convert it to the unsigned
 		# integer representation for internal use
 		try:
-			data = int(data, 16)
+			data = int(data, 16) if type(data) != int else data
 		except ValueError:
 			raise ValidationError("Device ID is not a valid hex number")
 		return super(HexIntegerField, self).to_internal_value(data)
@@ -34,7 +33,7 @@ class HexIntegerField(IntegerField):
 # Serializers
 class DeviceSerializerMixin(ModelSerializer):
 	class Meta:
-		fields = ("name", "registration_id", "device_id", "active", "date_created")
+		fields = ("id", "name", "registration_id", "device_id", "active", "date_created")
 		read_only_fields = ("date_created", )
 
 		# See https://github.com/tomchristie/django-rest-framework/issues/1101
@@ -59,28 +58,49 @@ class APNSDeviceSerializer(ModelSerializer):
 class GCMDeviceSerializer(ModelSerializer):
 	device_id = HexIntegerField(
 		help_text="ANDROID_ID / TelephonyManager.getDeviceId() (e.g: 0x01)",
-		style={'input_type': 'text'},
-		required=False
+		style={"input_type": "text"},
+		required=False,
+		allow_null=True
 	)
 
 	class Meta(DeviceSerializerMixin.Meta):
 		model = GCMDevice
 
-		extra_kwargs = {
-			# Work around an issue with validating the uniqueness of
-			# registration ids of up to 4k
-			'registration_id': {
-				'validators': [
-					UniqueValidator(queryset=GCMDevice.objects.all())
-				]
-			}
-		}
+		extra_kwargs = {"id": {"read_only": False, "required": False}}
 
 	def validate_device_id(self, value):
 		# device ids are 64 bit unsigned values
 		if value > UNSIGNED_64BIT_INT_MAX_VALUE:
 			raise ValidationError("Device ID is out of range")
 		return value
+
+	def validate(self, attrs):
+		devices = None
+		primary_key = None
+		request_method = None
+
+		if self.initial_data.get("registration_id", None):
+			if self.instance:
+				request_method = "update"
+				primary_key = self.instance.id
+			else:
+				request_method = "create"
+		else:
+			if self.context["request"].method in ["PUT", "PATCH"]:
+				request_method = "update"
+				primary_key = attrs["id"]
+			elif self.context["request"].method == "POST":
+				request_method = "create"
+
+		if request_method == "update":
+			devices = GCMDevice.objects.filter(registration_id=attrs["registration_id"]) \
+				.exclude(id=primary_key)
+		elif request_method == "create":
+			devices = GCMDevice.objects.filter(registration_id=attrs["registration_id"])
+
+		if devices:
+			raise ValidationError({'registration_id': 'This field must be unique.'})
+		return attrs
 
 
 # Permissions


### PR DESCRIPTION
When the serializer is nested the unique validator on registration_id
does not behave correctly.  This is a known issue with DRF
see: https://github.com/tomchristie/django-rest-framework/issues/2403

Added missing allow_null to device_id field

Fixes #270