### PR TITLE
Enabled support for arbitrary user model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ For APNS, you are required to include ``APNS_CERTIFICATE``.
 - ``APNS_PORT``: The port used along with APNS_HOST. Defaults to 2195.
 - ``GCM_POST_URL``: The full url that GCM notifications will be POSTed to. Defaults to https://android.googleapis.com/gcm/send.
 - ``GCM_MAX_RECIPIENTS``: The maximum amount of recipients that can be contained per bulk message. If the ``registration_ids`` list is larger than that number, multiple bulk messages will be sent. Defaults to 1000 (the maximum amount supported by GCM).
+- ``USER_MODEL``: Your user model of choice. Eg. ``myapp.User``. Defaults to ``settings.AUTH_USER_MODEL``.
 
 Sending messages
 ----------------

--- a/push_notifications/admin.py
+++ b/push_notifications/admin.py
@@ -1,18 +1,23 @@
+from django.apps import apps
 from django.contrib import admin, messages
-from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
 from .gcm import GCMError
 from .models import APNSDevice, GCMDevice, get_expired_tokens
+from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 
 
-User = get_user_model()
+User = apps.get_model(*SETTINGS["USER_MODEL"].split("."))
 
 
 class DeviceAdmin(admin.ModelAdmin):
 	list_display = ("__str__", "device_id", "user", "active", "date_created")
-	search_fields = ("name", "device_id", "user__%s" % (User.USERNAME_FIELD))
 	list_filter = ("active", )
 	actions = ("send_message", "send_bulk_message", "prune_devices", "enable", "disable")
+
+	if hasattr(User, "USERNAME_FIELD"):
+		search_fields = ("name", "device_id", "user__%s" % (User.USERNAME_FIELD))
+	else:
+		search_fields = ("name", "device_id")
 
 	def send_messages(self, request, queryset, bulk=False):
 		"""

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
-from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from .fields import HexIntegerField
+from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
 
 
 @python_2_unicode_compatible
@@ -13,7 +13,7 @@ class Device(models.Model):
 	name = models.CharField(max_length=255, verbose_name=_("Name"), blank=True, null=True)
 	active = models.BooleanField(verbose_name=_("Is active"), default=True,
 		help_text=_("Inactive devices will not be sent notifications"))
-	user = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
+	user = models.ForeignKey(SETTINGS["USER_MODEL"], blank=True, null=True)
 	date_created = models.DateTimeField(verbose_name=_("Creation date"), auto_now_add=True, null=True)
 
 	class Meta:

--- a/push_notifications/settings.py
+++ b/push_notifications/settings.py
@@ -19,3 +19,7 @@ if settings.DEBUG:
 else:
 	PUSH_NOTIFICATIONS_SETTINGS.setdefault("APNS_HOST", "gateway.push.apple.com")
 	PUSH_NOTIFICATIONS_SETTINGS.setdefault("APNS_FEEDBACK_HOST", "feedback.push.apple.com")
+
+
+# User model
+PUSH_NOTIFICATIONS_SETTINGS.setdefault("USER_MODEL", settings.AUTH_USER_MODEL)


### PR DESCRIPTION
This enables the use of custom models.

A user can define which model to use by setting the `PUSH_NOTIFICATIONS_SETTINGS` key `USER_MODEL` to a model on the format `appname.Model`. The default user model is `settings.AUTH_USER_MODEL` which is the current user model in the library.

The `admin.py`'s `search_fields` only contains the user model's `USERNAME_FIELD` if the user model actually has that field.