### PR TITLE
new settings `POST_RECREATE_USER`

### DIFF
--- a/push_notifications/settings.py
+++ b/push_notifications/settings.py
@@ -23,3 +23,6 @@ else:
 
 # User model
 PUSH_NOTIFICATIONS_SETTINGS.setdefault("USER_MODEL", settings.AUTH_USER_MODEL)
+
+# DRF
+PUSH_NOTIFICATIONS_SETTINGS.setdefault("POST_RECREATE_USER", False)


### PR DESCRIPTION
Add new settings **POST_RECREATE_USER**.

This is necessary when user want reauthorized on one device in another account. Device `registration_id + user` will deleted and created with new authorization.

By default this property is disabled. For activation you need add to your `settings.py`:

```python
PUSH_NOTIFICATION_SETTINGS = {
   ...
   "POST_RECREATE_USER": True,
   ...
}
```