### PR TITLE
Fix support for sending GCM messages to topic subscribers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,13 +129,14 @@ bulk notifications instead of single ones.
 Sending messages to topic members
 ---------------------------------
 GCM topic messaging allows your app server to send a message to multiple devices that have opted in to a particular topic. Based on the publish/subscribe model, topic messaging supports unlimited subscriptions per app. Developers can choose any topic name that matches the regular expression, "/topics/[a-zA-Z0-9-_.~%]+".
+Note: gcm_send_bulk_message must be used when sending messages to topic subscribers, and setting the first param to any value other than None will result in a 400 Http error.
 
 .. code-block:: python
 
-	from push_notifications.gcm import gcm_send_message
+	from push_notifications.gcm import gcm_send_bulk_message
 
         # First param is "None" because no Registration_id is needed, the message will be sent to all devices subscribed to the topic.
-        gcm_send_message(None, "Hello members of my_topic!", topic='/topics/my_topic')
+        gcm_send_bulk_message(None, {"message": "Hello members of my_topic!"}, to="/topics/my_topic")
 
 Reference: `GCM Documentation <https://developers.google.com/cloud-messaging/topic-messaging>`_
 

--- a/push_notifications/gcm.py
+++ b/push_notifications/gcm.py
@@ -107,7 +107,7 @@ def _gcm_send_json(registration_ids, data, **kwargs):
 	This will send the notification as json data.
 	"""
 
-	values = {"registration_ids": registration_ids}
+	values = {"registration_ids": registration_ids} if registration_ids else {}
 
 	if data is not None:
 		values["data"] = data
@@ -120,7 +120,7 @@ def _gcm_send_json(registration_ids, data, **kwargs):
 	data = json.dumps(values, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 	response = json.loads(_gcm_send(data, "application/json"))
-	if response["failure"] or response["canonical_ids"]:
+	if response.get("failure") or response.get("canonical_ids"):
 		ids_to_remove, old_new_ids = [], []
 		throw_error = False
 		for index, result in enumerate(response["results"]):
@@ -192,7 +192,8 @@ def gcm_send_bulk_message(registration_ids, data, **kwargs):
 	A reference of extra keyword arguments sent to the server is available here:
 	https://developers.google.com/cloud-messaging/server-ref#downstream
 	"""
-
+	if registration_ids is None and "/topics/" not in kwargs.get("to", ""):
+		return
 	# GCM only allows up to 1000 reg ids per bulk message
 	# https://developer.android.com/google/gcm/gcm.html#request
 	if registration_ids:
@@ -203,4 +204,4 @@ def gcm_send_bulk_message(registration_ids, data, **kwargs):
 				ret.append(_gcm_send_json(chunk, data, **kwargs))
 			return ret
 
-		return _gcm_send_json(registration_ids, data, **kwargs)
+	return _gcm_send_json(registration_ids, data, **kwargs)


### PR DESCRIPTION
gcm_send_bulk_message did not allow passing a registration_ids value of None.
Update README.rst with correct example for send messages to topics