### PR TITLE
Add possibility to use different badge values in bulk send

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,8 @@ value per user. Assuming User model has a method get_badge returning badge count
 
 .. code-block:: python
 
-	devices.send_message("Happy name day!", badge=lambda token: APNSDevice.objects.get(registration_id=token).user.get_badge())
+	devices.send_message("Happy name day!",
+						 badge=lambda token: APNSDevice.objects.get(registration_id=token).user.get_badge())
 
 
 Sending messages to topic members

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,13 @@ Sending messages in bulk
 Sending messages in bulk makes use of the bulk mechanics offered by GCM and APNS. It is almost always preferable to send
 bulk notifications instead of single ones.
 
+It's also possible to pass badge parameter as a function which accepts token parameter in order to set different badge
+value per user. Assuming User model has a method get_badge returning badge count for a user:
+
+.. code-block:: python
+
+	devices.send_message("Happy name day!", badge=lambda token: APNSDevice.objects.get(registration_id=token).user.get_badge())
+
 
 Sending messages to topic members
 ---------------------------------

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -161,7 +161,7 @@ def _apns_send(
 		aps_data["alert"] = alert
 
 	if badge is not None:
-		aps_data["badge"] = badge
+		aps_data["badge"] = badge if not callable(badge) else badge(token)
 
 	if sound is not None:
 		aps_data["sound"] = sound


### PR DESCRIPTION
It's very valuable to set a proper badge value for different users (for now only one value for all the pushes possible) even when sending messages in bulk, this is an example of usage:

APNSDevice.objects.filter(user_id__in=user_ids).send_message(
        text, 
        badge=lambda token: APNSDevice.objects.get(registration_id=token).user.get_badges()
)
