### PR TITLE
Full implementation for multiple mobile applications (solves #130, supercedes #226)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ GCM, APNS or WNS devices and in the action dropdown, select "Send test message" 
 Note that sending a non-bulk test message to more than one device will just iterate over the devices and send multiple
 single messages.
 
+The application supports multiple mobile applications with separate application IDs using one server simultaneously.
+
 Dependencies
 ------------
 Django 1.8 is required. Support for older versions is available in the release 1.2.1.
@@ -65,15 +67,36 @@ Settings list
 -------------
 All settings are contained in a ``PUSH_NOTIFICATIONS_SETTINGS`` dict.
 
-In order to use GCM, you are required to include ``GCM_API_KEY``.
-For APNS, you are required to include ``APNS_CERTIFICATE``.
-For WNS, you need both the ``WNS_PACKAGE_SECURITY_KEY`` and the ``WNS_SECRET_KEY``.
+In order to use GCM, you are required to include one of ``GCM_API_KEY``, ``GCM_API_KEYS``, or ``GCM_API_KEYS_MODEL``.
+For APNS, you are required to include ``APNS_CERTIFICATE``, ``APNS_CERTIFICATES``, or ``APNS_CERTIFICATES_MODEL``.
+For WNS, you are required to use one of the ``WNS_PACKAGE_SECURITY_ID`` and ``WNS_SECRET_KEY`` pair,
+``WNS_PACKAGE_SECURITY_IDS`` and ``WNS_SECRET_KEYS`` pair, or
+``WNS_PACKAGE_SECURITY_IDS_MODEL`` and ``WNS_SECRET_KEYS_MODEL`` pair.
 
 - ``APNS_CERTIFICATE``: Absolute path to your APNS certificate file. Certificates with passphrases are not supported.
+- ``APNS_CERTIFICATES``: A dictionary reflecting separate application IDs to separate APNS certificate files.
+- ``APNS_CERTIFICATES_MODEL``: A dictionary containing description of a database model to reflect
+  application ID to APNS certificate file path.
+    - ``'model'`` - a model name like ``'my_application.MyModel'``
+    - ``'key'`` - a field name of the model referenced above, containing an application ID like ``'application_id'``
+    - ``'value'`` - a path to the field from the model referenced above, which contains an APNS certificate
+      file path, or just having a type django.db.models.fields.FileField, like ``'certificate'``
 - ``APNS_CA_CERTIFICATES``: Absolute path to a CA certificates file for APNS. Optional - do not set if not needed. Defaults to None.
 - ``GCM_API_KEY``: Your API key for GCM.
-- ``WNS_PACKAGE_SECURITY_KEY``: TODO
+- ``GCM_API_KEYS``: A dictionary reflecting separate application IDs to separate GCM API keys.
+- ``GCM_API_KEYS_MODEL``: A dictionary containing description of a database model to reflect application IDs to
+  GCM API keys.
+    - ``'model'`` - a model name like ``'my_application.MyModel'``
+    - ``'key'`` - a field name of the model referenced above, containing an application ID like ``'application_id'``
+    - ``'value'`` - a path to the field from the model referenced above, which contains a GCM API key like ``'api_key'``
+- ``APNS_HOST``: The hostname used for the APNS
+  sockets.
+- ``WNS_PACKAGE_SECURITY_ID``: TODO
+- ``WNS_PACKAGE_SECURITY_IDS``: TODO
+- ``WNS_PACKAGE_SECURITY_IDS_MODEL``: TODO
 - ``WNS_SECRET_KEY``: TODO
+- ``WNS_SECRET_KEYS``: TODO
+- ``WNS_SECRET_KEYS_MODEL``: TODO
 - ``APNS_HOST``: The hostname used for the APNS sockets.
    - When ``DEBUG=True``, this defaults to ``gateway.sandbox.push.apple.com``.
    - When ``DEBUG=False``, this defaults to ``gateway.push.apple.com``.
@@ -149,6 +172,74 @@ Note: gcm_send_bulk_message must be used when sending messages to topic subscrib
         gcm_send_bulk_message(None, {"message": "Hello members of my_topic!"}, to="/topics/my_topic")
 
 Reference: `GCM Documentation <https://developers.google.com/cloud-messaging/topic-messaging>`_
+
+Multiple mobile applications
+----------------------------
+
+In order to use multiple mobile applications on the same server, you should provide some method to associate the application IDs
+and correspondent application keys or certificates.
+
+If your are planning to use some not big and static number of mobile applications, you can use a static dictionary directly in
+your settings file. Use ``APNS_CERTIFICATES`` and ``GCM_API_KEYS`` settings to store this dictionary for APNS and GCM
+correspondently. The ``APNS_CERTIFICATE`` and ``GCM_API_KEY`` settings are used as defaults.
+
+.. code-block:: python
+
+	PUSH_NOTIFICATIONS_SETTINGS = {
+		"GCM_API_KEY": "<your default application api key>",
+		"GCM_API_KEYS": {
+		    "<application ID 1>":"<your api key 1>",
+		    "<application ID 2>":"<your api key 2>",
+		    ...
+		},
+		"APNS_CERTIFICATE": "/path/to/your/default/certificate.pem",
+		"APNS_CERTIFICATES": {
+		    "<application ID 1>":"/path/to/your/certificate1.pem",
+		    "<application ID 2>":"/path/to/your/certificate2.pem",
+		    ...
+		}
+	}
+
+If your are planning to use dynamic and/or big number of mobile applications, you can use a dynamic access to
+the database table containig records describing applications. Use ``APNS_CERTIFICATES_MODEL``
+and ``GCM_API_KEYS_MODEL`` settings to describe model(s) containing reflection
+of application IDs to the correspondent values. The ``APNS_CERTIFICATE`` and ``GCM_API_KEY`` settings are used
+as defaults.
+
+Let say, the application ``applications`` contains a model ``ApplicationModel`` which contains three fields to
+reflect an application ID to the correspondent application credentials:
+
+.. code-block:: python
+
+    class ApplicationModel(models.Model):
+        application_id = models.CharField(max_length=64,unique=True)
+        gcm_api_key = models.TextField(null=True,blank=True)
+        apns_certificate = models.FileField(null=True,blank=True)
+
+Then settings for the application should look like:
+
+.. code-block:: python
+
+	PUSH_NOTIFICATIONS_SETTINGS = {
+		"GCM_API_KEY": "<your default application api key>",
+		"GCM_API_KEYS_MODEL": {
+		    "model":"applications.ApplicationModel",
+		    "key":"application_id",
+		    "value":"gcm_api_key",
+		},
+		"APNS_CERTIFICATE": "/path/to/your/default/certificate.pem",
+		"APNS_CERTIFICATES_MODEL": {
+		    "model":"applications.ApplicationModel",
+		    "key":"application_id",
+		    "value":"apns_certificate",
+		}
+	}
+
+Definitely, either your mobile application should store it's application ID in the Device instance
+together with a registration ID while registering, or your server should identify the mobile
+application, while the mobile application instance is registering itself on the server.
+You can use application access token for the purpose in the latter case.
+
 
 Administration
 --------------

--- a/push_notifications/__init__.py
+++ b/push_notifications/__init__.py
@@ -1,7 +1,17 @@
+import sys
+
 __author__ = "Jerome Leclanche"
 __email__ = "jerome@leclan.ch"
 __version__ = "1.4.1"
 
 
 class NotificationError(Exception):
-	pass
+    pass
+
+
+if sys.version_info.major > 2:
+    def decodestr(s):
+        return s
+else:
+    def decodestr(s):
+        return s.decode('utf-8')

--- a/push_notifications/admin.py
+++ b/push_notifications/admin.py
@@ -85,11 +85,10 @@ class DeviceAdmin(admin.ModelAdmin):
 		# if the user doesn't select all the devices for pruning, we
 		# could very easily leave an expired device as active.  Maybe
 		#  this is just a bad API.
-		expired = get_expired_tokens()
-		devices = queryset.filter(registration_id__in=expired)
-		for d in devices:
-			d.active = False
-			d.save()
+		app_ids = set(queryset.values_list('application_id', flat=True).distinct())
+		for app_id in app_ids:
+			expired = get_expired_tokens(app_id)
+			queryset.filter(registration_id__in=expired).update(active=False)
 
 
 class GCMDeviceAdmin(DeviceAdmin):

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -34,7 +34,7 @@ class HexIntegerField(IntegerField):
 # Serializers
 class DeviceSerializerMixin(ModelSerializer):
 	class Meta:
-		fields = ("id", "name", "registration_id", "device_id", "active", "date_created")
+		fields = ("id", "name", "application_id", "registration_id", "device_id", "active", "date_created")
 		read_only_fields = ("date_created",)
 
 		# See https://github.com/tomchristie/django-rest-framework/issues/1101

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -15,6 +15,7 @@ from binascii import unhexlify
 from django.core.exceptions import ImproperlyConfigured
 from . import NotificationError
 from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+from .dynamic import get_apns_certificate, get_apns_host, get_apns_port, get_apns_feedback_host, get_apns_feedback_port
 
 
 APNS_ERROR_MESSAGES = {
@@ -64,8 +65,8 @@ def _check_certificate(ss):
 		raise ImproperlyConfigured("The APNS certificate doesn't contain a private key")
 
 
-def _apns_create_socket(address_tuple, certfile=None):
-	certfile = certfile or SETTINGS.get("APNS_CERTIFICATE")
+def _apns_create_socket(address_tuple, application_id=None, certfile=None):
+	certfile = certfile or get_apns_certificate(application_id)
 	if not certfile:
 		raise ImproperlyConfigured(
 			'You need to set PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] to send messages through APNS.'
@@ -88,12 +89,20 @@ def _apns_create_socket(address_tuple, certfile=None):
 	return sock
 
 
-def _apns_create_socket_to_push(certfile=None):
-	return _apns_create_socket((SETTINGS["APNS_HOST"], SETTINGS["APNS_PORT"]), certfile)
+def _apns_create_socket_to_push(application_id=None, certfile=None):
+	return _apns_create_socket(
+		(get_apns_host(application_id), get_apns_port(application_id)),
+		application_id=application_id,
+		certfile=certfile
+	)
 
 
-def _apns_create_socket_to_feedback(certfile=None):
-	return _apns_create_socket((SETTINGS["APNS_FEEDBACK_HOST"], SETTINGS["APNS_FEEDBACK_PORT"]), certfile)
+def _apns_create_socket_to_feedback(application_id=None, certfile=None):
+	return _apns_create_socket(
+		(get_apns_feedback_host(application_id), get_apns_feedback_port(application_id)),
+		application_id=application_id,
+		certfile=certfile
+	)
 
 
 def _apns_pack_frame(token_hex, payload, identifier, expiration, priority):
@@ -139,7 +148,7 @@ def _apns_check_errors(sock):
 
 
 def _apns_send(
-	token, alert, badge=None, sound=None, category=None, content_available=False,
+	token, alert, application_id=None, badge=None, sound=None, category=None, content_available=False,
 	action_loc_key=None, loc_key=None, loc_args=[], extra={}, identifier=0,
 	expiration=None, priority=10, socket=None, certfile=None
 ):
@@ -190,7 +199,7 @@ def _apns_send(
 	if socket:
 		socket.write(frame)
 	else:
-		with closing(_apns_create_socket_to_push(certfile)) as socket:
+		with closing(_apns_create_socket_to_push(application_id=application_id, certfile=certfile)) as socket:
 			socket.write(frame)
 			_apns_check_errors(socket)
 
@@ -236,7 +245,7 @@ def _apns_receive_feedback(socket):
 	return expired_token_list
 
 
-def apns_send_message(registration_id, alert, **kwargs):
+def apns_send_message(registration_id, alert, application_id=None, certfile=None, **kwargs):
 	"""
 	Sends an APNS notification to a single registration_id.
 	This will send the notification as form data.
@@ -248,10 +257,10 @@ def apns_send_message(registration_id, alert, **kwargs):
 	to this for silent notifications.
 	"""
 
-	return _apns_send(registration_id, alert, **kwargs)
+	return _apns_send(registration_id, alert, application_id=application_id, certfile=certfile, **kwargs)
 
 
-def apns_send_bulk_message(registration_ids, alert, **kwargs):
+def apns_send_bulk_message(registration_ids, alert, application_id=None, certfile=None, **kwargs):
 	"""
 	Sends an APNS notification to one or more registration_ids.
 	The registration_ids argument needs to be a list.
@@ -260,20 +269,25 @@ def apns_send_bulk_message(registration_ids, alert, **kwargs):
 	it won't be included in the notification. You will need to pass None
 	to this for silent notifications.
 	"""
-	certfile = kwargs.get("certfile", None)
-	with closing(_apns_create_socket_to_push(certfile)) as socket:
+	with closing(_apns_create_socket_to_push(application_id)) as socket:
+		res = []
 		for identifier, registration_id in enumerate(registration_ids):
-			res = _apns_send(registration_id, alert, identifier=identifier, socket=socket, **kwargs)
+			r = _apns_send(
+				registration_id, alert,
+				application_id=application_id, certfile=certfile,
+				identifier=identifier, socket=socket, **kwargs
+			)
+			res.append(r)
 		_apns_check_errors(socket)
 		return res
 
 
-def apns_fetch_inactive_ids(certfile=None):
+def apns_fetch_inactive_ids(application_id=None, certfile=None):
 	"""
 	Queries the APNS server for id's that are no longer active since
 	the last fetch
 	"""
-	with closing(_apns_create_socket_to_feedback(certfile)) as socket:
+	with closing(_apns_create_socket_to_feedback(application_id=application_id, certfile=certfile)) as socket:
 		inactive_ids = []
 		# Maybe we should have a flag to return the timestamp?
 		# It doesn't seem that useful right now, though.

--- a/push_notifications/dynamic.py
+++ b/push_notifications/dynamic.py
@@ -1,0 +1,87 @@
+from django.core.exceptions import ImproperlyConfigured
+from .settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+from .modeldict import FieldPairDict
+
+try:
+	basestring
+except:
+	basestring = str
+
+
+def _get_application_settings(application_id, settings_key, error_message):
+	if not application_id:  # old behaviour
+		value = SETTINGS.get(settings_key, None)
+		if not value:
+			raise ImproperlyConfigured(error_message)
+		return value
+	# new behaviour, settings dict
+	values = SETTINGS.get(settings_key + "S", {})
+
+	if application_id in values:
+		value = values.get(application_id)
+		if value is not None:
+			return value
+
+	# new behaviour, getting from the model
+	values_model = SETTINGS.get(settings_key + "S_MODEL", None)
+	if values_model:
+		model = values_model.get('model', None)
+		key = values_model.get('key', None)
+		value = values_model.get('value', None)
+		if model and key and value:
+			values = FieldPairDict(model, key, value)
+
+	if application_id in values:
+		value = values.get(application_id)
+		if value is not None:
+			return value
+
+	value = SETTINGS.get(settings_key, None)
+	if not value:
+		raise ImproperlyConfigured(error_message)
+	return value
+
+
+def get_gcm_api_key(application_id=None):
+	return _get_application_settings(application_id, "GCM_API_KEY", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_fcm_api_key(application_id=None):
+	return _get_application_settings(application_id, "FCM_API_KEY", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_apns_certificate(application_id=None):
+	r = _get_application_settings(application_id, "APNS_CERTIFICATE", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+	if not isinstance(r, basestring):
+		# probably the (Django) file, and file path should be got
+		if hasattr(r, 'path'):
+			return r.path
+		elif (hasattr(r, 'has_key') or hasattr(r, '__contains__')) and 'path' in r:
+			return r['path']
+		else:
+			raise ImproperlyConfigured("The APNS certificate settings value should be a string, or should have a 'path' attribute or key")
+	return r
+
+
+def get_apns_host(application_id=None):
+	return _get_application_settings(application_id, "APNS_HOST", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_apns_port(application_id=None):
+	return _get_application_settings(application_id, "APNS_PORT", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_apns_feedback_host(application_id=None):
+	return _get_application_settings(application_id, "APNS_FEEDBACK_HOST", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_apns_feedback_port(application_id=None):
+	return _get_application_settings(application_id, "APNS_FEEDBACK_PORT", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_wns_package_security_id(application_id=None):
+	return _get_application_settings(application_id, "WNS_PACKAGE_SECURITY_ID", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')
+
+
+def get_wns_secret_key(application_id=None):
+	return _get_application_settings(application_id, "WNS_SECRET_KEY", 'You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages')

--- a/push_notifications/management/commands/prune_devices.py
+++ b/push_notifications/management/commands/prune_devices.py
@@ -7,10 +7,8 @@ class Command(BaseCommand):
 
 	def handle(self, *args, **options):
 		from push_notifications.models import APNSDevice, get_expired_tokens
-		expired = get_expired_tokens()
-		devices = APNSDevice.objects.filter(registration_id__in=expired)
-		for d in devices:
-			self.stdout.write('deactivating [%s]' % d.registration_id)
-			d.active = False
-			d.save()
-		self.stdout.write('deactivated %d devices' % len(devices))
+		app_ids = set(APNSDevice.objects.values_list('application_id', flat=True).distinct())
+		for app_id in app_ids:
+			expired = get_expired_tokens(app_id)
+			cnt = APNSDevice.objects.filter(registration_id__in=expired).update(active=False)
+			self.stdout.write('deactivated %d devices' % cnt)

--- a/push_notifications/migrations/0006_applicationmodel.py
+++ b/push_notifications/migrations/0006_applicationmodel.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_notifications', '0005_auto_20161117_1306'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ApplicationModel',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('application_id', models.CharField(unique=True, max_length=64, verbose_name='Application ID')),
+                ('gcm_api_key', models.TextField(null=True, verbose_name='GCM API Key', blank=True)),
+                ('fcm_api_key', models.TextField(null=True, verbose_name='FCM API Key', blank=True)),
+                ('apns_certificate', models.FileField(upload_to='apns_certificates', null=True, verbose_name='APNS Certificate', blank=True)),
+                ('wns_package_security_id', models.TextField(null=True, verbose_name='WNS Package Security ID', blank=True)),
+                ('wns_secret_key', models.TextField(null=True, verbose_name='WNS Secret Key', blank=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AddField(
+            model_name='apnsdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='gcmdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='wnsdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/push_notifications/modeldict.py
+++ b/push_notifications/modeldict.py
@@ -1,0 +1,99 @@
+from django.apps import apps
+from collections import MutableMapping
+
+try:
+	basestring
+except:
+	basestring = str
+
+
+class ModelDict(MutableMapping):
+	def __init__(self, model, key_field):
+		self._model = model
+		self._key = key_field
+
+	def _fix_model(self):
+		if isinstance(self._model, basestring):
+			self._model = apps.get_model(*self._model.split('.', 1))
+
+	def _get_value(self, o):
+		return {f.name: getattr(o, f.name) for f in o._meta.fields}
+
+	def _set_value(self, o, value):
+		for k in value:
+			# some inconsistency with natural dict: ignore absence instead of deleting;
+			# use None to clean the field value instead
+			setattr(o, k, value[k])
+		o.save()
+
+	def get(self, key, *d):
+		self._fix_model()
+		q = self._model.objects.filter(**{self._key: key})
+		if q:
+			return self._get_value(q[0])
+		if len(d):
+			return d[0]
+		raise KeyError("No such key in the database")
+
+	def has_key(self, key):
+		self._fix_model()
+		q = self._model.objects.filter(**{self._key: key})
+		return bool(q)
+
+	def set(self, key, value):
+		self._fix_model()
+		q = self._model.objects.filter(**{self._key: key})
+		if q:
+			o = q[0]
+		else:
+			o = self._model(**{self._key: key})
+		self._set_value(o, value)
+
+	def remove(self, key):
+		self._fix_model()
+		self._model.objects.filter(**{self._key: key}).delete()
+
+	def __getitem__(self, key):
+		return self.get(key)
+
+	def __setitem__(self, key, value):
+		return self.set(key, value)
+
+	def __delitem__(self, key):
+		return self.remove(key)
+
+	def __iter__(self):
+		self._fix_model()
+		for o in self._model.objects.all():
+			yield getattr(o, self._key)
+
+	def __len__(self):
+		self._fix_model()
+		return self._model.objects.count()
+
+
+class FieldPairDict(ModelDict):
+	def __init__(self, model, key_field, value_field):
+		ModelDict.__init__(self, model, key_field)
+		self._value = value_field
+		if '.' in self._value:
+			self._value = self._value.split('.')
+		elif '__' in self._value:
+			self._value = self._value.split('__')
+		else:
+			self._value = [self._value]
+
+	def _get_value(self, o, path=None):
+		if path is None:
+			path = self._value
+		v = ModelDict._get_value(self, o)[path[0]]
+		path = path[1:]
+		if not path:
+			return v
+		return self._get_value(v, path)
+
+	def _set_value(self, o, value):
+		if len(self._value) > 1:
+			raise AttributeError("Dict assignment over relations is ambiguous")
+		setattr(o, self._value[0], value)
+		o.save()

--- a/push_notifications/models.py
+++ b/push_notifications/models.py
@@ -24,6 +24,11 @@ class Device(models.Model):
 	date_created = models.DateTimeField(
 		verbose_name=_("Creation date"), auto_now_add=True, null=True
 	)
+	application_id = models.CharField(
+		max_length=64, verbose_name=_("Application ID"),
+		help_text=_("Opaque application identity, should be filled in for multiple key/certificate access"),
+		blank=True, null=True
+	)
 
 	class Meta:
 		abstract = True
@@ -43,25 +48,33 @@ class GCMDeviceManager(models.Manager):
 class GCMDeviceQuerySet(models.query.QuerySet):
 	def send_message(self, message, **kwargs):
 		if self:
-			from .gcm import send_bulk_message
+			from .gcm import gcm_send_bulk_message
 
 			data = kwargs.pop("extra", {})
 			if message is not None:
 				data["message"] = message
 
+			app_ids = set(self.filter(active=True).values_list('application_id', flat=True).distinct())
 			response = []
 			for cloud_type in ("GCM", "FCM"):
-				reg_ids = list(
-					self.filter(active=True, cloud_message_type=cloud_type).values_list(
-						"registration_id", flat=True
+				for app_id in app_ids:
+					reg_ids = list(
+						self.filter(
+							active=True, cloud_message_type=cloud_type,
+							application_id=app_id
+						).values_list(
+							'registration_id', flat=True
+						)
 					)
-				)
-				if reg_ids:
-					r = send_bulk_message(
-						registration_ids=reg_ids, data=data, cloud_type=cloud_type, **kwargs
-					)
-					response.append(r)
-
+					if reg_ids:
+						r = gcm_send_bulk_message(
+							registration_ids=reg_ids, data=data,
+							application_id=app_id, cloud_type=cloud_type, **kwargs
+						)
+						if hasattr(r, 'keys'):
+							response += [r]
+						elif hasattr(r, '__getitem__'):
+							response += r
 			return response
 
 
@@ -85,14 +98,14 @@ class GCMDevice(Device):
 		verbose_name = _("GCM device")
 
 	def send_message(self, message, **kwargs):
-		from .gcm import send_message
+		from .gcm import gcm_send_message
 
 		data = kwargs.pop("extra", {})
 		if message is not None:
 			data["message"] = message
-
-		return send_message(
+		return gcm_send_message(
 			registration_id=self.registration_id, data=data,
+			application_id=self.application_id,
 			cloud_type=self.cloud_message_type, **kwargs
 		)
 
@@ -103,11 +116,20 @@ class APNSDeviceManager(models.Manager):
 
 
 class APNSDeviceQuerySet(models.query.QuerySet):
-	def send_message(self, message, **kwargs):
+	def send_message(self, message, certfile=None, **kwargs):
 		if self:
 			from .apns import apns_send_bulk_message
-			reg_ids = list(self.filter(active=True).values_list("registration_id", flat=True))
-			return apns_send_bulk_message(registration_ids=reg_ids, alert=message, **kwargs)
+
+			app_ids = set(self.filter(active=True).values_list('application_id', flat=True).distinct())
+			res = []
+			for app_id in app_ids:
+				reg_ids = list(self.filter(active=True, application_id=app_id).values_list('registration_id', flat=True))
+				r = apns_send_bulk_message(registration_ids=reg_ids, alert=message, application_id=app_id, certfile=certfile, **kwargs)
+				if hasattr(r, 'keys'):
+					res += [r]
+				elif hasattr(r, '__getitem__'):
+					res += r
+			return res
 
 
 class APNSDevice(Device):
@@ -124,10 +146,15 @@ class APNSDevice(Device):
 	class Meta:
 		verbose_name = _("APNS device")
 
-	def send_message(self, message, **kwargs):
+	def send_message(self, message, certfile=None, **kwargs):
 		from .apns import apns_send_message
 
-		return apns_send_message(registration_id=self.registration_id, alert=message, **kwargs)
+		return apns_send_message(
+			registration_id=self.registration_id,
+			alert=message,
+			application_id=self.application_id, certfile=certfile,
+			**kwargs
+		)
 
 
 class WNSDeviceManager(models.Manager):
@@ -140,8 +167,16 @@ class WNSDeviceQuerySet(models.query.QuerySet):
 		if self:
 			from .wns import wns_send_bulk_message
 
-			reg_ids = list(self.filter(active=True).values_list("registration_id", flat=True))
-			return wns_send_bulk_message(uri_list=reg_ids, message=message, **kwargs)
+			app_ids = set(self.filter(active=True).values_list('application_id', flat=True).distinct())
+			res = []
+			for app_id in app_ids:
+				reg_ids = list(self.filter(active=True, application_id=app_id).values_list('registration_id', flat=True))
+				r = wns_send_bulk_message(uri_list=reg_ids, message=message, **kwargs)
+				if hasattr(r, 'keys'):
+					res += [r]
+				elif hasattr(r, '__getitem__'):
+					res += r
+			return res
 
 
 class WNSDevice(Device):
@@ -159,11 +194,27 @@ class WNSDevice(Device):
 	def send_message(self, message, **kwargs):
 		from .wns import wns_send_message
 
-		return wns_send_message(uri=self.registration_id, message=message, **kwargs)
+		return wns_send_message(uri=self.registration_id, message=message, application_id=self.application_id, **kwargs)
 
 
 # This is an APNS-only function right now, but maybe GCM will implement it
 # in the future.  But the definition of 'expired' may not be the same. Whatevs
-def get_expired_tokens(cerfile=None):
+def get_expired_tokens(application_id):
 	from .apns import apns_fetch_inactive_ids
-	return apns_fetch_inactive_ids(cerfile)
+	return apns_fetch_inactive_ids(application_id)
+
+
+class ApplicationModelBase(models.Model):
+	application_id = models.CharField(max_length=64, verbose_name=_("Application ID"), unique=True)
+	gcm_api_key = models.TextField(verbose_name=_("GCM API Key"), null=True, blank=True)
+	fcm_api_key = models.TextField(verbose_name=_("FCM API Key"), null=True, blank=True)
+	apns_certificate = models.FileField(verbose_name=_("APNS Certificate"), null=True, blank=True, upload_to='apns_certificates')
+	wns_package_security_id = models.TextField(verbose_name=_("WNS Package Security ID"), null=True, blank=True)
+	wns_secret_key = models.TextField(verbose_name=_("WNS Security Key"), null=True, blank=True)
+
+	class Meta:
+		abstract = True
+
+
+class ApplicationModel(ApplicationModelBase):
+	pass

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,8 @@ from .test_models import *
 from .test_gcm_push_payload import *
 from .test_apns_push_payload import *
 from .test_management_commands import *
+from .test_modeldict import *
+from .test_dynamic_settings import *
 from .test_apns_certfilecheck import *
 from .test_wns import *
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,3 +24,8 @@ ROOT_URLCONF = "core.urls"
 SECRET_KEY = "foobar"
 
 PUSH_NOTIFICATIONS_SETTINGS = {}
+
+import os
+
+ROOT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
+MEDIA_ROOT = os.path.join(ROOT_DIR,"testmedia")

--- a/tests/test_apns_certfilecheck.py
+++ b/tests/test_apns_certfilecheck.py
@@ -5,36 +5,35 @@ from django.test import TestCase
 from push_notifications.models import APNSDevice
 from ._mock import mock
 
-
 class APNSCertfileTestCase(TestCase):
-	def test_apns_send_message_good_certfile(self):
-		path = os.path.join(os.path.dirname(__file__), "test_data", "good_revoked.pem")
-		settings.PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] = path
-		device = APNSDevice.objects.create(
-			registration_id="1212121212121212121212121212121212121212121212121212121212121212",
-		)
-		with mock.patch("ssl.wrap_socket") as ws:
-			with mock.patch("socket.socket") as socket:
-				socket.return_value = 123
-				device.send_message("Hello world")
-				ws.assert_called_once_with(123, ca_certs=None, certfile=path, ssl_version=3)
+    def test_apns_send_message_good_certfile(self):
+        path = os.path.join(os.path.dirname(__file__),"test_data","good_revoked.pem")
+        settings.PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] = path
+        device = APNSDevice.objects.create(
+            registration_id="1212121212121212121212121212121212121212121212121212121212121212",
+        )
+        with mock.patch("ssl.wrap_socket") as ws:
+            with mock.patch("socket.socket") as socket:
+                socket.return_value = 123
+                device.send_message("Hello world")
+                ws.assert_called_once_with(123, ca_certs=None, certfile=path, ssl_version=3)
 
-	def test_apns_send_message_raises_no_privatekey(self):
-		path = os.path.join(os.path.dirname(__file__), "test_data", "without_private.pem")
-		settings.PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] = path
-		device = APNSDevice.objects.create(
-			registration_id="1212121212121212121212121212121212121212121212121212121212121212",
-		)
-		with self.assertRaises(ImproperlyConfigured) as ic:
-			device.send_message("Hello world")
-		self.assertTrue(bool(ic.exception.args))
+    def test_apns_send_message_raises_no_privatekey(self):
+        path = os.path.join(os.path.dirname(__file__),"test_data","without_private.pem")
+        settings.PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] = path
+        device = APNSDevice.objects.create(
+            registration_id="1212121212121212121212121212121212121212121212121212121212121212",
+        )
+        with self.assertRaises(ImproperlyConfigured) as ic:
+            device.send_message("Hello world")
+        self.assertTrue(bool(ic.exception.args))
 
-	def test_apns_send_message_raises_passwd(self):
-		path = os.path.join(os.path.dirname(__file__), "test_data", "good_with_passwd.pem")
-		settings.PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] = path
-		device = APNSDevice.objects.create(
-			registration_id="1212121212121212121212121212121212121212121212121212121212121212",
-		)
-		with self.assertRaises(ImproperlyConfigured) as ic:
-			device.send_message("Hello world")
-		self.assertTrue(bool(ic.exception.args))
+    def test_apns_send_message_raises_passwd(self):
+        path = os.path.join(os.path.dirname(__file__),"test_data","good_with_passwd.pem")
+        settings.PUSH_NOTIFICATIONS_SETTINGS["APNS_CERTIFICATE"] = path
+        device = APNSDevice.objects.create(
+            registration_id="1212121212121212121212121212121212121212121212121212121212121212",
+        )
+        with self.assertRaises(ImproperlyConfigured) as ic:
+            device.send_message("Hello world")
+        self.assertTrue(bool(ic.exception.args))

--- a/tests/test_apns_push_payload.py
+++ b/tests/test_apns_push_payload.py
@@ -1,40 +1,83 @@
+
+import os
 from django.test import TestCase
 from push_notifications.apns import _apns_send, APNSDataOverflow
 from ._mock import mock
 
+from django.conf import settings
+from push_notifications.models import ApplicationModel
 
 class APNSPushPayloadTest(TestCase):
 	def test_push_payload(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			_apns_send(
-				"123", "Hello world", badge=1, sound="chime",
-				extra={"custom_data": 12345}, expiration=3, socket=socket
-			)
+			_apns_send("123", "Hello world", None,
+				badge=1, sound="chime", extra={"custom_data": 12345}, expiration=3, socket=socket)
 			p.assert_called_once_with(
-				"123",
-				b'{"aps":{"alert":"Hello world","badge":1,"sound":"chime"},"custom_data":12345}',
-				0, 3, 10)
+				"123", b'{"aps":{"alert":"Hello world","badge":1,"sound":"chime"},"custom_data":12345}',
+				0, 3, 10
+			)
+
 
 	def test_localised_push_with_empty_body(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			_apns_send("123", None, loc_key="TEST_LOC_KEY", expiration=3, socket=socket)
+			_apns_send("123", None, None, loc_key="TEST_LOC_KEY", expiration=3, socket=socket)
 			p.assert_called_once_with(
-				"123", b'{"aps":{"alert":{"loc-key":"TEST_LOC_KEY"}}}', 0, 3, 10
+				"123",
+				b'{"aps":{"alert":{"loc-key":"TEST_LOC_KEY"}}}', 0, 3, 10
 			)
 
 	def test_using_extra(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
 			_apns_send(
-				"123", "sample", extra={"foo": "bar"}, identifier=10,
-				expiration=30, priority=10, socket=socket
+				"123", "sample", None, extra={"foo": "bar"},
+				identifier=10, expiration=30, priority=10, socket=socket
 			)
-			p.assert_called_once_with("123", b'{"aps":{"alert":"sample"},"foo":"bar"}', 10, 30, 10)
+			p.assert_called_once_with(
+				"123", 
+				b'{"aps":{"alert":"sample"},"foo":"bar"}', 10, 30, 10
+			)
 
 	def test_oversized_payload(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			self.assertRaises(APNSDataOverflow, _apns_send, "123", "_" * 2049, socket=socket)
+			self.assertRaises(APNSDataOverflow, _apns_send, "123", "_" * 2049, None, socket=socket)
 			p.assert_has_calls([])
+
+class APNSPushSettingsTest(TestCase):
+	def test_push_payload_with_app_id(self):
+		settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES_MODEL'] = {
+		    'model':'push_notifications.ApplicationModel',
+		    'key':'application_id',
+		    'value':'apns_certificate',
+		}
+		import ssl
+		from django.core.files.base import ContentFile
+		path = os.path.join(os.path.dirname(__file__),"test_data","good_revoked.pem")
+		f = open(path,'r')
+		content = f.read()
+		f.close()
+		f = ContentFile(content)
+		a = ApplicationModel.objects.create(application_id='qwertyxxx')
+		a.apns_certificate.save("uiopcertxxx",f)
+		path = a.apns_certificate.path
+		socket = mock.MagicMock()
+		with mock.patch("ssl.wrap_socket",return_value=socket) as s:
+			with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+				_apns_send("123", "Hello world", 'qwertyxxx',
+					badge=1, sound="chime", extra={"custom_data": 12345}, expiration=3)
+				s.assert_called_once_with(*s.call_args[0],ca_certs=None,certfile=path,ssl_version=ssl.PROTOCOL_TLSv1)
+				p.assert_called_once_with("123",
+					b'{"aps":{"alert":"Hello world","badge":1,"sound":"chime"},"custom_data":12345}', 0, 3, 10)
+	def tearDown(self):
+	    # teardown temporary media
+	    from django.conf import settings
+	    import os
+	    for root, dirs, files in os.walk(settings.MEDIA_ROOT, topdown=False):
+	        for name in files:
+	            os.remove(os.path.join(root, name))
+	        for name in dirs:
+	            os.rmdir(os.path.join(root, name))
+	    os.removedirs(settings.MEDIA_ROOT)

--- a/tests/test_dynamic_settings.py
+++ b/tests/test_dynamic_settings.py
@@ -1,0 +1,76 @@
+import json
+import mock
+from django.test import TestCase
+from django.utils import timezone
+from push_notifications import dynamic
+from django.conf import settings
+
+from django.core.exceptions import ImproperlyConfigured
+
+from push_notifications.models import ApplicationModel
+
+class DynamicSettingsTestCase(TestCase):
+    def test_base_settings(self):
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TEST'] = 'test'
+        assert dynamic._get_application_settings('qwerty','TEST','Test Exception') == 'test'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TESTS'] = {
+            'qwerty':'uiop'
+        }
+        assert dynamic._get_application_settings('qwerty','TEST','Test Exception') == 'uiop'
+        assert dynamic._get_application_settings('uiop','TEST','Test Exception') == 'test'
+        try:
+            dynamic._get_application_settings('qwerty','NOTPRESENT','Test Exception')
+            assert False
+        except Exception as ex:
+            assert type(ex) == ImproperlyConfigured
+            assert ex.args and ex.args[0] == 'Test Exception'
+
+    def test_default_if_none(self):
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TEST'] = 'test'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TESTS'] = {
+            'qwerty':'uiop',
+            'qwerty2':None
+        }
+        assert dynamic._get_application_settings('qwerty','TEST','Test Exception') == 'uiop'
+        assert dynamic._get_application_settings('qwerty2','TEST','Test Exception') == 'test'
+
+    def test_database_settings(self):
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TEST'] = 'test'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['TESTS_MODEL'] = {
+            'model':'push_notifications.ApplicationModel',
+            'key':'application_id',
+            'value':'gcm_api_key',
+        }
+        ApplicationModel.objects.create(application_id='qwerty2',gcm_api_key='uiop2')
+        assert dynamic._get_application_settings('qwerty2','TEST','Test Exception') == 'uiop2'
+        assert dynamic._get_application_settings('uiop2','TEST','Test Exception') == 'test'
+        try:
+            dynamic._get_application_settings('qwerty','NOTPRESENT','Test Exception')
+            assert False
+        except Exception as ex:
+            assert type(ex) == ImproperlyConfigured
+            assert ex.args and ex.args[0] == 'Test Exception'
+
+    def test_push_settings(self):
+        try:
+            r = dynamic.get_gcm_api_key()
+            assert False
+        except Exception as ex:
+            assert type(ex) == ImproperlyConfigured
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEY'] = 'testkey'
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATE'] = 'testcert'
+        assert dynamic.get_gcm_api_key() == 'testkey'
+        assert dynamic.get_apns_certificate() == 'testcert'
+
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'qwerty':'uiopkey'
+        }
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES'] = {
+            'qwerty':'uiopcert'
+        }
+        assert dynamic.get_gcm_api_key() == 'testkey'
+        assert dynamic.get_apns_certificate() == 'testcert'
+        assert dynamic.get_gcm_api_key('uiop') == 'testkey'
+        assert dynamic.get_apns_certificate('uiop') == 'testcert'
+        assert dynamic.get_gcm_api_key('qwerty') == 'uiopkey'
+        assert dynamic.get_apns_certificate('qwerty') == 'uiopcert'

--- a/tests/test_gcm_push_payload.py
+++ b/tests/test_gcm_push_payload.py
@@ -7,23 +7,40 @@ from ._mock import mock
 class GCMPushPayloadTest(TestCase):
 	def test_push_payload(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
-			send_message("abc", {"message": "Hello world"}, "GCM")
+			send_message("abc", {"message": "Hello world"}, cloud_type="GCM")
 			p.assert_called_once_with(
 				b"data.message=Hello+world&registration_id=abc",
-				"application/x-www-form-urlencoded;charset=UTF-8")
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				None)
+
+	def test_push_payload_with_app_id(self):
+		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+			send_message("abc", {"message": "Hello world"}, 'qwerty')
+			p.assert_called_once_with(
+				b"data.message=Hello+world&registration_id=abc",
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				'qwerty')
+		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+			send_message("abc", {"message": "Hello world"}, application_id='qwerty')
+			p.assert_called_once_with(
+				b"data.message=Hello+world&registration_id=abc",
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				'qwerty')
 
 	def test_push_payload_params(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
 			send_message(
-				"abc", {"message": "Hello world"}, "GCM", delay_while_idle=True, time_to_live=3600
+				"abc", {"message": "Hello world"}, cloud_type="GCM", delay_while_idle=True, time_to_live=3600
 			)
 			p.assert_called_once_with(
 				b"data.message=Hello+world&delay_while_idle=1&registration_id=abc&time_to_live=3600",
-				"application/x-www-form-urlencoded;charset=UTF-8")
+				"application/x-www-form-urlencoded;charset=UTF-8",
+				None)
 
 	def test_bulk_push_payload(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON_RESPONSE) as p:
-			send_bulk_message(["abc", "123"], {"message": "Hello world"}, "GCM")
+			send_bulk_message(["abc", "123"], {"message": "Hello world"}, cloud_type="GCM")
 			p.assert_called_once_with(
 				b'{"data":{"message":"Hello world"},"registration_ids":["abc","123"]}',
-				"application/json")
+				"application/json",
+				None)

--- a/tests/test_modeldict.py
+++ b/tests/test_modeldict.py
@@ -1,0 +1,45 @@
+import json
+import mock
+from django.test import TestCase
+from django.utils import timezone
+from django.contrib.auth.models import User
+from push_notifications import modeldict
+
+class ModelDictTestCase(TestCase):
+    def test_model_dict_simple_cases(self):
+        for k in (1,2,3,4,5):
+            user = User.objects.create(
+                username = 'u%s' % k,
+                first_name= "user u%s" % k
+            )
+        md = modeldict.ModelDict('auth.User','username')
+        keys = list(md.keys())
+        keys.sort()
+        assert tuple(keys) == ('u1','u2','u3','u4','u5')
+        assert 'u2' in md
+        assert 'uu2' not in md
+        for k in keys:
+            assert md[k]['first_name'] == "user %s" % k
+        for k in keys:
+            md[k] = {"last_name":"user last name %s" % k}
+        for k in keys:
+            assert md[k]['last_name'] == "user last name %s" % k
+        assert md.get('notpresent','default') == 'default'
+
+    def test_field_pair_dict_simple_cases(self):
+        for k in (1,2,3,4,5):
+            user = User.objects.create(
+                username = 'u%s' % k,
+                first_name= "user u%s" % k
+            )
+        md = modeldict.FieldPairDict('auth.User','username','first_name')
+        keys = list(md.keys())
+        keys.sort()
+        assert tuple(keys) == ('u1','u2','u3','u4','u5')
+        for k in keys:
+            assert md[k] == "user %s" % k
+        for k in keys:
+            md[k] = "user last name %s" % k
+        for k in keys:
+            assert md[k] == "user last name %s" % k
+        assert md.get('notpresent','default') == 'default'

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,425 +1,632 @@
 import json
+
 from django.test import TestCase
 from django.utils import timezone
 from push_notifications.gcm import GCMError, send_bulk_message
 from push_notifications.models import GCMDevice, APNSDevice
 from ._mock import mock
-
+import os
 
 # Mock responses
 
 GCM_PLAIN_RESPONSE = "id=1:08"
 GCM_JSON_RESPONSE = '{"multicast_id":108,"success":1,"failure":0,"canonical_ids":0,"results":[{"message_id":"1:08"}]}'
 GCM_MULTIPLE_JSON_RESPONSE = (
-	'{"multicast_id":108,"success":2,"failure":0,"canonical_ids":0,"results":'
-	'[{"message_id":"1:08"}, {"message_id": "1:09"}]}'
+    '{"multicast_id":108,"success":2,"failure":0,"canonical_ids":0,"results":'
+    '[{"message_id":"1:08"}, {"message_id": "1:09"}]}'
 )
 GCM_JSON_RESPONSE_ERROR = (
-	'{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, "results":'
-	' [{"error": "NotRegistered"}, {"message_id": "0:1433830664381654%3449593ff9fd7ecd"}, '
-	'{"error": "InvalidRegistration"}]}'
+    '{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, "results":'
+    ' [{"error": "NotRegistered"}, {"message_id": "0:1433830664381654%3449593ff9fd7ecd"}, '
+    '{"error": "InvalidRegistration"}]}'
 )
 GCM_JSON_RESPONSE_ERROR_B = (
-	'{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, '
-	'"results": [{"error": "MismatchSenderId"}, {"message_id": '
-	'"0:1433830664381654%3449593ff9fd7ecd"}, {"error": "InvalidRegistration"}]}'
+    '{"success":1, "failure": 2, "canonical_ids": 0, "cast_id": 6358665107659088804, '
+    '"results": [{"error": "MismatchSenderId"}, {"message_id": '
+    '"0:1433830664381654%3449593ff9fd7ecd"}, {"error": "InvalidRegistration"}]}'
 )
 GCM_JSON_CANONICAL_ID_RESPONSE = (
-	'{"failure":0,"canonical_ids":1,"success":2,"multicast_id":7173139966327257000,"results":'
-	'[{"registration_id":"NEW_REGISTRATION_ID","message_id":"0:1440068396670935%6868637df9fd7ecd"},'
-	'{"message_id":"0:1440068396670937%6868637df9fd7ecd"}]}'
+    '{"failure":0,"canonical_ids":1,"success":2,"multicast_id":7173139966327257000,"results":'
+    '[{"registration_id":"NEW_REGISTRATION_ID","message_id":"0:1440068396670935%6868637df9fd7ecd"},'
+    '{"message_id":"0:1440068396670937%6868637df9fd7ecd"}]}'
 )
 GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE = (
-	'{"failure":0,"canonical_ids":1,"success":2,"multicast_id":7173139966327257000,'
-	'"results":[{"registration_id":"bar","message_id":"0:1440068396670935%6868637df9fd7ecd"}'
-	',{"message_id":"0:1440068396670937%6868637df9fd7ecd"}]}'
+    '{"failure":0,"canonical_ids":1,"success":2,"multicast_id":7173139966327257000,'
+    '"results":[{"registration_id":"bar","message_id":"0:1440068396670935%6868637df9fd7ecd"}'
+    ',{"message_id":"0:1440068396670937%6868637df9fd7ecd"}]}'
 )
 
 
 class ModelTestCase(TestCase):
-	def _create_devices(self, devices):
-		for device in devices:
-			GCMDevice.objects.create(registration_id=device)
+    def _create_devices(self, devices, **kwargs):
+        for device in devices:
+            GCMDevice.objects.create(registration_id=device, **kwargs)
 
-	def _create_fcm_devices(self, devices):
-		for device in devices:
-			GCMDevice.objects.create(registration_id=device, cloud_message_type="FCM")
+    def test_can_save_gcm_device(self):
+        device = GCMDevice.objects.create(
+            registration_id="a valid registration id"
+        )
+        assert device.id is not None
+        assert device.date_created is not None
+        assert device.date_created.date() == timezone.now().date()
 
-	def test_can_save_gcm_device(self):
-		device = GCMDevice.objects.create(registration_id="a valid registration id")
-		assert device.id is not None
-		assert device.date_created is not None
-		assert device.date_created.date() == timezone.now().date()
+    def test_can_create_save_device(self):
+        device = APNSDevice.objects.create(
+            registration_id="a valid registration id"
+        )
+        assert device.id is not None
+        assert device.date_created is not None
+        assert device.date_created.date() == timezone.now().date()
 
-	def test_can_create_save_device(self):
-		device = APNSDevice.objects.create(registration_id="a valid registration id")
-		assert device.id is not None
-		assert device.date_created is not None
-		assert device.date_created.date() == timezone.now().date()
+    def test_gcm_send_message(self):
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+        )
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+            device.send_message("Hello world")
+            p.assert_called_once_with(
+                b"data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None)
 
-	def test_gcm_send_message(self):
-		device = GCMDevice.objects.create(registration_id="abc")
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE
-		) as p:
-				device.send_message("Hello world")
-				p.assert_called_once_with(
-					b"data.message=Hello+world&registration_id=abc",
-					"application/x-www-form-urlencoded;charset=UTF-8"
-				)
+    def test_gcm_send_message_with_app_id(self):
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="qwerty",
+        )
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+            device.send_message("Hello world")
+            p.assert_called_once_with(
+                b"data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                "qwerty")
 
-	def test_gcm_send_message_extra(self):
-		device = GCMDevice.objects.create(registration_id="abc")
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE
-		) as p:
-			device.send_message("Hello world", extra={"foo": "bar"})
-			p.assert_called_once_with(
-				b"data.foo=bar&data.message=Hello+world&registration_id=abc",
-				"application/x-www-form-urlencoded;charset=UTF-8"
-			)
+    def test_gcm_send_message_extra(self):
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+        )
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+            device.send_message("Hello world", extra={"foo": "bar"})
+            p.assert_called_once_with(
+                b"data.foo=bar&data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None)
 
-	def test_gcm_send_message_collapse_key(self):
-		device = GCMDevice.objects.create(registration_id="abc")
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE
-		) as p:
-			device.send_message("Hello world", collapse_key="test_key")
-			p.assert_called_once_with(
-				b"collapse_key=test_key&data.message=Hello+world&registration_id=abc",
-				"application/x-www-form-urlencoded;charset=UTF-8"
-			)
+    def test_gcm_send_message_collapse_key(self):
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+        )
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+            device.send_message("Hello world", collapse_key="test_key")
+            p.assert_called_once_with(
+                b"collapse_key=test_key&data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None)
 
-	def test_gcm_send_message_to_multiple_devices(self):
-		self._create_devices(["abc", "abc1"])
+    def test_gcm_send_message_to_multiple_devices(self):
+        self._create_devices(['abc', 'abc1'])
 
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
-		) as p:
-			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc", "abc1"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE) as p:
+            GCMDevice.objects.all().send_message("Hello world")
+            p.assert_called_once_with(
+                json.dumps({
+                    "data": { "message": "Hello world" },
+                    "registration_ids": ["abc", "abc1"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
-	def test_gcm_send_message_active_devices(self):
-		GCMDevice.objects.create(registration_id="abc", active=True)
-		GCMDevice.objects.create(registration_id="xyz", active=False)
+    def test_gcm_send_message_active_devices(self):
+        GCMDevice.objects.create(
+            registration_id="abc",
+            active=True
+        )
 
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
-		) as p:
-			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+        GCMDevice.objects.create(
+            registration_id="xyz",
+            active=False
+        )
 
-	def test_gcm_send_message_collapse_to_multiple_devices(self):
-		self._create_devices(["abc", "abc1"])
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE) as p:
+            GCMDevice.objects.all().send_message("Hello world")
+            p.assert_called_once_with(
+                json.dumps({
+                    "data": { "message": "Hello world" },
+                    "registration_ids": ["abc"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
-		) as p:
-				GCMDevice.objects.all().send_message("Hello world", collapse_key="test_key")
-				p.assert_called_once_with(
-					json.dumps({
-						"collapse_key": "test_key",
-						"data": {"message": "Hello world"},
-						"registration_ids": ["abc", "abc1"]
-					}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+    def test_gcm_send_message_extra_to_multiple_devices(self):
+        self._create_devices(['abc', 'abc1'])
 
-	def test_gcm_send_message_to_single_device_with_error(self):
-		# these errors are device specific, device.active will be set false
-		devices = ["abc", "abc1"]
-		self._create_devices(devices)
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE) as p:
+            GCMDevice.objects.all().send_message("Hello world", extra={"foo": "bar"})
+            p.assert_called_once_with(
+                json.dumps({
+                    "data": { "foo": "bar", "message": "Hello world" },
+                    "registration_ids": ["abc", "abc1"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
-		errors = ["Error=NotRegistered", "Error=InvalidRegistration"]
-		for index, error in enumerate(errors):
-			with mock.patch(
-				"push_notifications.gcm._gcm_send", return_value=error):
-				device = GCMDevice.objects.get(registration_id=devices[index])
-				device.send_message("Hello World!")
-				assert GCMDevice.objects.get(registration_id=devices[index]).active is False
+    def test_gcm_send_message_collapse_to_multiple_devices(self):
+        self._create_devices(['abc', 'abc1'])
 
-	def test_gcm_send_message_to_single_device_with_error_b(self):
-		device = GCMDevice.objects.create(registration_id="abc")
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE) as p:
+            GCMDevice.objects.all().send_message("Hello world", collapse_key="test_key")
+            p.assert_called_once_with(
+                json.dumps({
+                    "collapse_key": "test_key",
+                    "data": { "message": "Hello world" },
+                    "registration_ids": ["abc", "abc1"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value="Error=MismatchSenderId"
-		):
-			# these errors are not device specific, GCMError should be thrown
-			with self.assertRaises(GCMError):
-				device.send_message("Hello World!")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
+    def test_gcm_send_message_to_single_device_with_error(self):
+        # these errors are device specific, device.active will be set false
+        device_list = ['abc', 'abc1']
+        self._create_devices(device_list)
+        errors = ["Error=NotRegistered", "Error=InvalidRegistration"]
+        for index, error in enumerate(errors):
+            with mock.patch("push_notifications.gcm._gcm_send",
+                            return_value=error) as p:
+                device = GCMDevice.objects. \
+                    get(registration_id=device_list[index])
+                device.send_message("Hello World!")
+                assert GCMDevice.objects.get(registration_id=device_list[index]).active is False
 
-	def test_gcm_send_message_to_multiple_devices_with_error(self):
-		self._create_devices(["abc", "abc1", "abc2"])
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_JSON_RESPONSE_ERROR
-		):
-			devices = GCMDevice.objects.all()
-			devices.send_message("Hello World")
-			assert not GCMDevice.objects.get(registration_id="abc").active
-			assert GCMDevice.objects.get(registration_id="abc1").active
-			assert not GCMDevice.objects.get(registration_id="abc2").active
+    def test_gcm_send_message_to_single_device_with_error_b(self):
+        # these errors are not device specific, GCMError should be thrown
+        device_list = ['abc']
+        self._create_devices(device_list)
+        with mock.patch(
+            "push_notifications.gcm._gcm_send", return_value="Error=MismatchSenderId"
+        ):
+            device = GCMDevice.objects. \
+                get(registration_id=device_list[0])
+            with self.assertRaises(GCMError):
+                device.send_message("Hello World!")
+            assert GCMDevice.objects.get(registration_id=device_list[0]).active is True
 
-	def test_gcm_send_message_to_multiple_devices_with_error_b(self):
-		self._create_devices(["abc", "abc1", "abc2"])
+    def test_gcm_send_message_to_multiple_devices_with_error(self):
+        self._create_devices(["abc", "abc1", "abc2"])
+        with mock.patch("push_notifications.gcm._gcm_send",
+                        return_value=GCM_JSON_RESPONSE_ERROR) as p:
+            devices = GCMDevice.objects.all()
+            devices.send_message("Hello World")
+            assert not GCMDevice.objects.get(registration_id="abc").active
+            assert GCMDevice.objects.get(registration_id="abc1").active
+            assert not GCMDevice.objects.get(registration_id="abc2").active
 
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_JSON_RESPONSE_ERROR_B
-		):
-			devices = GCMDevice.objects.all()
-			with self.assertRaises(GCMError):
-				devices.send_message("Hello World")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
-			assert GCMDevice.objects.get(registration_id="abc1").active is True
-			assert GCMDevice.objects.get(registration_id="abc2").active is False
+    def test_gcm_send_message_to_multiple_devices_with_error_b(self):
+        self._create_devices(["abc", "abc1", "abc2"])
 
-	def test_gcm_send_message_to_multiple_devices_with_canonical_id(self):
-		self._create_devices(["foo", "bar"])
-		with mock.patch(
-			"push_notifications.gcm._gcm_send", return_value=GCM_JSON_CANONICAL_ID_RESPONSE
-		):
-			GCMDevice.objects.all().send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id="foo").exists()
-			assert GCMDevice.objects.filter(registration_id="bar").exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists() is True
+        with mock.patch(
+            "push_notifications.gcm._gcm_send", return_value=GCM_JSON_RESPONSE_ERROR_B
+        ):
+            devices = GCMDevice.objects.all()
+            with self.assertRaises(GCMError):
+                devices.send_message("Hello World")
+            assert GCMDevice.objects.get(registration_id="abc").active is True
+            assert GCMDevice.objects.get(registration_id="abc1").active is True
+            assert GCMDevice.objects.get(registration_id="abc2").active is False
 
-	def test_gcm_send_message_to_single_user_with_canonical_id(self):
-		old_registration_id = "foo"
-		self._create_devices([old_registration_id])
+    def test_gcm_send_message_to_multiple_devices_with_canonical_id(self):
+        self._create_devices(["foo", "bar"])
 
-		gcm_reg_blob = "id=1:2342\nregistration_id=NEW_REGISTRATION_ID"
-		with mock.patch("push_notifications.gcm._gcm_send", return_value=gcm_reg_blob):
-			GCMDevice.objects.get(registration_id=old_registration_id).send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id=old_registration_id).exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists()
+        with mock.patch(
+            "push_notifications.gcm._gcm_send", return_value=GCM_JSON_CANONICAL_ID_RESPONSE
+        ):
+            GCMDevice.objects.all().send_message("Hello World")
+            assert not GCMDevice.objects.filter(registration_id="foo").exists()
+            assert GCMDevice.objects.filter(registration_id="bar").exists()
+            assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists() is True
 
-	def test_gcm_send_message_to_same_devices_with_canonical_id(self):
-		first_device = GCMDevice.objects.create(registration_id="foo", active=True)
-		second_device = GCMDevice.objects.create(registration_id="bar", active=False)
+    def test_gcm_send_message_to_single_user_with_canonical_id(self):
+        old_registration_id = "foo"
+        self._create_devices([old_registration_id])
 
-		with mock.patch(
-			"push_notifications.gcm._gcm_send",
-			return_value=GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE
-		):
-			GCMDevice.objects.all().send_message("Hello World")
+        gcm_reg_blob = "id=1:2342\nregistration_id=NEW_REGISTRATION_ID"
+        with mock.patch("push_notifications.gcm._gcm_send", return_value=gcm_reg_blob):
+            GCMDevice.objects.get(registration_id=old_registration_id).send_message("Hello World")
+            assert not GCMDevice.objects.filter(registration_id=old_registration_id).exists()
+            assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists()
 
-		assert first_device.active is True
-		assert second_device.active is False
+    def test_gcm_send_message_to_same_devices_with_canonical_id(self):
+        first_device = GCMDevice.objects.create(registration_id="foo", active=True)
+        second_device = GCMDevice.objects.create(registration_id="bar", active=False)
 
-	def test_fcm_send_message(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_PLAIN_RESPONSE
-		) as p:
-				device.send_message("Hello world")
-				p.assert_called_once_with(
-					b"data.message=Hello+world&registration_id=abc",
-					"application/x-www-form-urlencoded;charset=UTF-8"
-				)
+        with mock.patch(
+            "push_notifications.gcm._gcm_send",
+            return_value=GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE
+        ):
+            GCMDevice.objects.all().send_message("Hello World")
 
-	def test_fcm_send_message_extra(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_PLAIN_RESPONSE
-		) as p:
-			device.send_message("Hello world", extra={"foo": "bar"})
-			p.assert_called_once_with(
-				b"data.foo=bar&data.message=Hello+world&registration_id=abc",
-				"application/x-www-form-urlencoded;charset=UTF-8"
-			)
+        assert first_device.active is True
+        assert second_device.active is False
 
-	def test_fcm_send_message_collapse_key(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_PLAIN_RESPONSE
-		) as p:
-			device.send_message("Hello world", collapse_key="test_key")
-			p.assert_called_once_with(
-				b"collapse_key=test_key&data.message=Hello+world&registration_id=abc",
-				"application/x-www-form-urlencoded;charset=UTF-8"
-			)
+    def test_fcm_send_message(self):
+        device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
+        with mock.patch(
+            "push_notifications.gcm._fcm_send", return_value=GCM_PLAIN_RESPONSE
+        ) as p:
+                device.send_message("Hello world")
+                p.assert_called_once_with(
+                    b"data.message=Hello+world&registration_id=abc",
+                    "application/x-www-form-urlencoded;charset=UTF-8",
+                    None
+                )
 
-	def test_fcm_send_message_to_multiple_devices(self):
-		self._create_fcm_devices(["abc", "abc1"])
+    def test_fcm_send_message_with_app_id(self):
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="qwerty",
+            cloud_message_type="FCM"
+        )
+        with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_PLAIN_RESPONSE) as p:
+            device.send_message("Hello world")
+            p.assert_called_once_with(
+                b"data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                "qwerty"
+            )
 
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
-		) as p:
-			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc", "abc1"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+    def test_fcm_send_message_extra(self):
+        device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
+        with mock.patch(
+            "push_notifications.gcm._fcm_send", return_value=GCM_PLAIN_RESPONSE
+        ) as p:
+            device.send_message("Hello world", extra={"foo": "bar"})
+            p.assert_called_once_with(
+                b"data.foo=bar&data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None
+            )
 
-	def test_fcm_send_message_active_devices(self):
-		GCMDevice.objects.create(registration_id="abc", active=True, cloud_message_type="FCM")
-		GCMDevice.objects.create(registration_id="xyz", active=False, cloud_message_type="FCM")
+    def test_fcm_send_message_collapse_key(self):
+        device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
+        with mock.patch(
+            "push_notifications.gcm._fcm_send", return_value=GCM_PLAIN_RESPONSE
+        ) as p:
+            device.send_message("Hello world", collapse_key="test_key")
+            p.assert_called_once_with(
+                b"collapse_key=test_key&data.message=Hello+world&registration_id=abc",
+                "application/x-www-form-urlencoded;charset=UTF-8",
+                None
+            )
 
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
-		) as p:
-			GCMDevice.objects.all().send_message("Hello world")
-			p.assert_called_once_with(
-				json.dumps({
-					"data": {"message": "Hello world"},
-					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+    def test_fcm_send_message_to_multiple_devices(self):
+        self._create_devices(['abc','abc1'], cloud_message_type="FCM")
 
-	def test_fcm_send_message_collapse_to_multiple_devices(self):
-		self._create_fcm_devices(["abc", "abc1"])
+        with mock.patch(
+            "push_notifications.gcm._fcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
+        ) as p:
+            GCMDevice.objects.all().send_message("Hello world")
+            p.assert_called_once_with(
+                json.dumps({
+                    "data": {"message": "Hello world"},
+                    "registration_ids": ["abc", "abc1"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json", None)
 
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
-		) as p:
-				GCMDevice.objects.all().send_message("Hello world", collapse_key="test_key")
-				p.assert_called_once_with(
-					json.dumps({
-						"collapse_key": "test_key",
-						"data": {"message": "Hello world"},
-						"registration_ids": ["abc", "abc1"]
-					}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+    def test_fcm_send_message_active_devices(self):
+        GCMDevice.objects.create(registration_id="abc", active=True, cloud_message_type="FCM")
+        GCMDevice.objects.create(registration_id="xyz", active=False, cloud_message_type="FCM")
 
-	def test_fcm_send_message_to_single_device_with_error(self):
-		# these errors are device specific, device.active will be set false
-		devices = ["abc", "abc1"]
-		self._create_fcm_devices(devices)
+        with mock.patch(
+            "push_notifications.gcm._fcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE
+        ) as p:
+            GCMDevice.objects.all().send_message("Hello world")
+            p.assert_called_once_with(
+                json.dumps({
+                    "data": {"message": "Hello world"},
+                    "registration_ids": ["abc"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json", None)
 
-		errors = ["Error=NotRegistered", "Error=InvalidRegistration"]
-		for index, error in enumerate(errors):
-			with mock.patch(
-				"push_notifications.gcm._fcm_send", return_value=error):
-				device = GCMDevice.objects.get(registration_id=devices[index])
-				device.send_message("Hello World!")
-				assert GCMDevice.objects.get(registration_id=devices[index]).active is False
 
-	def test_fcm_send_message_to_single_device_with_error_b(self):
-		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
+    def test_fcm_send_message_extra_to_multiple_devices(self):
+        self._create_devices(['abc','abc1'], cloud_message_type="FCM")
 
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value="Error=MismatchSenderId"
-		):
-			# these errors are not device specific, GCMError should be thrown
-			with self.assertRaises(GCMError):
-				device.send_message("Hello World!")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
+        with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE) as p:
+            GCMDevice.objects.all().send_message("Hello world", extra={"foo": "bar"})
+            p.assert_called_once_with(
+                json.dumps({
+                    "data": { "foo": "bar", "message": "Hello world" },
+                    "registration_ids": ["abc", "abc1"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
-	def test_fcm_send_message_to_multiple_devices_with_error(self):
-		self._create_fcm_devices(["abc", "abc1", "abc2"])
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_JSON_RESPONSE_ERROR
-		):
-			devices = GCMDevice.objects.all()
-			devices.send_message("Hello World")
-			assert not GCMDevice.objects.get(registration_id="abc").active
-			assert GCMDevice.objects.get(registration_id="abc1").active
-			assert not GCMDevice.objects.get(registration_id="abc2").active
+    def test_fcm_send_message_collapse_to_multiple_devices(self):
+        self._create_devices(['abc','abc1'], cloud_message_type="FCM")
 
-	def test_fcm_send_message_to_multiple_devices_with_error_b(self):
-		self._create_fcm_devices(["abc", "abc1", "abc2"])
+        with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_MULTIPLE_JSON_RESPONSE) as p:
+            GCMDevice.objects.all().send_message("Hello world", collapse_key="test_key")
+            p.assert_called_once_with(
+                json.dumps({
+                    "collapse_key": "test_key",
+                    "data": { "message": "Hello world" },
+                    "registration_ids": ["abc", "abc1"]
+                }, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",None)
 
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_JSON_RESPONSE_ERROR_B
-		):
-			devices = GCMDevice.objects.all()
-			with self.assertRaises(GCMError):
-				devices.send_message("Hello World")
-			assert GCMDevice.objects.get(registration_id="abc").active is True
-			assert GCMDevice.objects.get(registration_id="abc1").active is True
-			assert GCMDevice.objects.get(registration_id="abc2").active is False
+    def test_fcm_send_message_to_single_device_with_error(self):
+        # these errors are device specific, device.active will be set false
+        devices = ["abc", "abc1"]
+        self._create_devices(devices, cloud_message_type="FCM")
 
-	def test_fcm_send_message_to_multiple_devices_with_canonical_id(self):
-		self._create_fcm_devices(["foo", "bar"])
-		with mock.patch(
-			"push_notifications.gcm._fcm_send", return_value=GCM_JSON_CANONICAL_ID_RESPONSE
-		):
-			GCMDevice.objects.all().send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id="foo").exists()
-			assert GCMDevice.objects.filter(registration_id="bar").exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists() is True
+        errors = ["Error=NotRegistered", "Error=InvalidRegistration"]
+        for index, error in enumerate(errors):
+            with mock.patch(
+                "push_notifications.gcm._fcm_send", return_value=error):
+                device = GCMDevice.objects.get(registration_id=devices[index])
+                device.send_message("Hello World!")
+                assert GCMDevice.objects.get(registration_id=devices[index]).active is False
 
-	def test_fcm_send_message_to_single_user_with_canonical_id(self):
-		old_registration_id = "foo"
-		self._create_fcm_devices([old_registration_id])
+    def test_fcm_send_message_to_single_device_with_error_b(self):
+        device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
 
-		gcm_reg_blob = "id=1:2342\nregistration_id=NEW_REGISTRATION_ID"
-		with mock.patch("push_notifications.gcm._fcm_send", return_value=gcm_reg_blob):
-			GCMDevice.objects.get(registration_id=old_registration_id).send_message("Hello World")
-			assert not GCMDevice.objects.filter(registration_id=old_registration_id).exists()
-			assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists()
+        with mock.patch(
+            "push_notifications.gcm._fcm_send", return_value="Error=MismatchSenderId"
+        ):
+            # these errors are not device specific, GCMError should be thrown
+            with self.assertRaises(GCMError):
+                device.send_message("Hello World!")
+            assert GCMDevice.objects.get(registration_id="abc").active is True
 
-	def test_fcm_send_message_to_same_devices_with_canonical_id(self):
-		first_device = GCMDevice.objects.create(
-			registration_id="foo", active=True, cloud_message_type="FCM"
-		)
-		second_device = GCMDevice.objects.create(
-			registration_id="bar", active=False, cloud_message_type="FCM"
-		)
+    def test_fcm_send_message_to_multiple_devices_with_error(self):
+        self._create_devices(['abc', 'abc1', 'abc2'], cloud_message_type="FCM")
+        with mock.patch("push_notifications.gcm._fcm_send",
+                        return_value=GCM_JSON_RESPONSE_ERROR) as p:
+            devices = GCMDevice.objects.all()
+            devices.send_message("Hello World")
+            assert not GCMDevice.objects.get(registration_id="abc").active
+            assert GCMDevice.objects.get(registration_id="abc1").active
+            assert not GCMDevice.objects.get(registration_id="abc2").active
 
-		with mock.patch(
-			"push_notifications.gcm._fcm_send",
-			return_value=GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE
-		):
-			GCMDevice.objects.all().send_message("Hello World")
+    def test_fcm_send_message_to_multiple_devices_with_error_b(self):
+        self._create_devices(['abc', 'abc1', 'abc2'], cloud_message_type="FCM")
+        with mock.patch("push_notifications.gcm._fcm_send",
+                        return_value=GCM_JSON_RESPONSE_ERROR_B) as p:
+            devices = GCMDevice.objects.all()
+            with self.assertRaises(GCMError):
+                devices.send_message("Hello World")
+            assert GCMDevice.objects.get(registration_id="abc").active
+            assert GCMDevice.objects.get(registration_id="abc1").active
+            assert not GCMDevice.objects.get(registration_id="abc2").active
 
-		assert first_device.active is True
-		assert second_device.active is False
+    def test_fcm_send_message_to_multiple_devices_with_canonical_id(self):
+        self._create_devices(['foo', 'bar'], cloud_message_type="FCM")
+        with mock.patch(
+            "push_notifications.gcm._fcm_send", return_value=GCM_JSON_CANONICAL_ID_RESPONSE
+        ):
+            GCMDevice.objects.all().send_message("Hello World")
+            assert not GCMDevice.objects.filter(registration_id="foo").exists()
+            assert GCMDevice.objects.filter(registration_id="bar").exists()
+            assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists() is True
 
-	def test_apns_send_message(self):
-		device = APNSDevice.objects.create(registration_id="abc")
-		socket = mock.MagicMock()
+    def test_fcm_send_message_to_single_user_with_canonical_id(self):
+        old_registration_id = 'foo'
+        self._create_devices([old_registration_id], cloud_message_type="FCM")
 
-		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			device.send_message("Hello world", socket=socket, expiration=1)
-			p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+        gcm_reg_blob = "id=1:2342\nregistration_id=NEW_REGISTRATION_ID"
+        with mock.patch("push_notifications.gcm._fcm_send", return_value=gcm_reg_blob):
+            GCMDevice.objects.get(registration_id=old_registration_id).send_message("Hello World")
+            assert not GCMDevice.objects.filter(registration_id=old_registration_id).exists()
+            assert GCMDevice.objects.filter(registration_id="NEW_REGISTRATION_ID").exists()
 
-	def test_apns_send_message_extra(self):
-		device = APNSDevice.objects.create(registration_id="abc")
-		socket = mock.MagicMock()
+    def test_fcm_send_message_to_same_devices_with_canonical_id(self):
+        first_device = GCMDevice.objects.create(
+            registration_id="foo", active=True, cloud_message_type="FCM"
+        )
+        second_device = GCMDevice.objects.create(
+            registration_id="bar", active=False, cloud_message_type="FCM"
+        )
 
-		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
-			device.send_message(
-				"Hello world", extra={"foo": "bar"}, socket=socket,
-				identifier=1, expiration=2, priority=5
-			)
-			p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"},"foo":"bar"}', 1, 2, 5)
+        with mock.patch(
+            "push_notifications.gcm._fcm_send",
+            return_value=GCM_JSON_CANONICAL_ID_SAME_DEVICE_RESPONSE
+        ):
+            GCMDevice.objects.all().send_message("Hello World")
 
-	def test_send_message_with_no_reg_ids(self):
-		self._create_devices(["abc", "abc1"])
+        assert first_device.active is True
+        assert second_device.active is False
 
-		with mock.patch("push_notifications.gcm._cm_send_plain", return_value="") as p:
-			GCMDevice.objects.filter(registration_id="xyz").send_message("Hello World")
-			p.assert_not_called()
+    def test_apns_send_message(self):
+        device = APNSDevice.objects.create(registration_id="abc")
+        socket = mock.MagicMock()
 
-		with mock.patch("push_notifications.gcm._cm_send_json", return_value="") as p:
-			reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
-			send_bulk_message(reg_ids, {"message": "Hello World"}, "GCM")
-			p.assert_called_once_with(
-				[u"abc", u"abc1"], {"message": "Hello World"}, cloud_type="GCM"
-			)
+        with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+            device.send_message("Hello world", socket=socket, expiration=1)
+            p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
 
-	def test_fcm_send_message_with_no_reg_ids(self):
-		self._create_fcm_devices(["abc", "abc1"])
+    def test_apns_send_message_extra(self):
+        device = APNSDevice.objects.create(registration_id="abc")
+        socket = mock.MagicMock()
 
-		with mock.patch("push_notifications.gcm._cm_send_plain", return_value="") as p:
-			GCMDevice.objects.filter(registration_id="xyz").send_message("Hello World")
-			p.assert_not_called()
+        with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+            device.send_message(
+                "Hello world", extra={"foo": "bar"}, socket=socket,
+                identifier=1, expiration=2, priority=5
+            )
+            p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"},"foo":"bar"}', 1, 2, 5)
 
-		with mock.patch("push_notifications.gcm._cm_send_json", return_value="") as p:
-			reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
-			send_bulk_message(reg_ids, {"message": "Hello World"}, "FCM")
-			p.assert_called_once_with(
-				[u"abc", u"abc1"], {"message": "Hello World"}, cloud_type="FCM"
-			)
+    def test_send_message_with_no_reg_ids(self):
+        self._create_devices(["abc", "abc1"])
 
-	def test_can_save_wsn_device(self):
-		device = GCMDevice.objects.create(registration_id="a valid registration id")
-		self.assertIsNotNone(device.pk)
-		self.assertIsNotNone(device.date_created)
-		self.assertEqual(device.date_created.date(), timezone.now().date())
+        with mock.patch("push_notifications.gcm._cm_send_plain", return_value="") as p:
+            GCMDevice.objects.filter(registration_id="xyz").send_message("Hello World")
+            p.assert_not_called()
+
+        with mock.patch("push_notifications.gcm._cm_send_json", return_value="") as p:
+            reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
+            send_bulk_message(reg_ids, {"message": "Hello World"}, cloud_type="GCM")
+            p.assert_called_once_with(
+                [u"abc", u"abc1"], {"message": "Hello World"}, application_id=None, cloud_type="GCM"
+            )
+
+    def test_fcm_send_message_with_no_reg_ids(self):
+        self._create_devices(["abc", "abc1"], cloud_message_type="FCM")
+
+        with mock.patch("push_notifications.gcm._cm_send_plain", return_value="") as p:
+            GCMDevice.objects.filter(registration_id="xyz").send_message("Hello World")
+            p.assert_not_called()
+
+        with mock.patch("push_notifications.gcm._cm_send_json", return_value="") as p:
+            reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
+            send_bulk_message(reg_ids, {"message": "Hello World"}, cloud_type="FCM")
+            p.assert_called_once_with(
+                [u"abc", u"abc1"], {"message": "Hello World"}, application_id=None, cloud_type="FCM"
+            )
+
+    def test_can_save_wsn_device(self):
+        device = GCMDevice.objects.create(registration_id="a valid registration id")
+        self.assertIsNotNone(device.pk)
+        self.assertIsNotNone(device.date_created)
+        self.assertEqual(device.date_created.date(), timezone.now().date())
+
+    def test_apns_send_message_cert(self):
+        device = APNSDevice.objects.create(registration_id="abc")
+        socket = mock.MagicMock()
+
+        with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+            with mock.patch("push_notifications.apns._apns_create_socket") as cs:
+                cs.return_value = socket
+                device.send_message(
+                    "Hello world", extra={"foo": "bar"},
+                    identifier=1, expiration=2, priority=5,
+                    certfile="12345"
+                )
+                p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"},"foo":"bar"}', 1, 2, 5)
+                cs.assert_called_once_with(('gateway.push.apple.com', 2195), application_id=None, certfile='12345')
+
+
+class APNSModelWithSettingsTestCase(TestCase):
+    def test_apns_send_message_with_app_id(self):
+        from django.conf import settings
+        path = os.path.join(os.path.dirname(__file__),"test_data","good_revoked.pem")
+        device = APNSDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        device2 = APNSDevice.objects.create(
+            registration_id="def",
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATE'] = path
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES'] = {
+            'asdfg':path
+        }
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_HOSTS'] = {
+            'asdfg':"111.222.333"
+        }
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_PORTS'] = {
+            'asdfg':334
+        }
+        import ssl
+        socket = mock.MagicMock()
+        with mock.patch("ssl.wrap_socket",return_value=socket) as s:
+            with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+                device.send_message("Hello world", expiration=1)
+                p.assert_called_once_with("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+                s.assert_called_once_with(*s.call_args[0],ca_certs=None,certfile=path,ssl_version=ssl.PROTOCOL_TLSv1)
+                socket.connect.assert_called_with(("111.222.333",334))
+        socket = mock.MagicMock()
+        with mock.patch("ssl.wrap_socket",return_value=socket) as s:
+            with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+                device2.send_message("Hello world", expiration=1)
+                p.assert_called_once_with("def", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+                s.assert_called_once_with(*s.call_args[0],ca_certs=None,certfile=path,ssl_version=ssl.PROTOCOL_TLSv1)
+                socket.connect.assert_called_with(("gateway.push.apple.com", 2195))
+
+    def test_apns_send_multi_message_with_app_id(self):
+        from django.conf import settings
+        path = os.path.join(os.path.dirname(__file__),"test_data","good_revoked.pem")
+        device = APNSDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        device = APNSDevice.objects.create(
+            registration_id="def",
+            application_id="asdfg"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['APNS_CERTIFICATES'] = {
+            'asdfg':path
+        }
+        import ssl
+        socket = mock.MagicMock()
+        with mock.patch("ssl.wrap_socket",return_value=socket) as s:
+            with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+                APNSDevice.objects.all().send_message("Hello world", expiration=1)
+                device.send_message("Hello world", expiration=1)
+                p.assert_any_call("abc", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+                p.assert_any_call("def", b'{"aps":{"alert":"Hello world"}}', 0, 1, 10)
+                s.assert_any_call(*s.call_args_list[0][0],ca_certs=None,certfile=path,ssl_version=ssl.PROTOCOL_TLSv1)
+
+
+
+class GCMModelWithSettingsTestCase(TestCase):
+    def test_gcm_send_message_with_app_id(self):
+        from django.conf import settings
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'asdfg':'uiopkey'
+        }
+        with mock.patch("push_notifications.gcm.urlopen") as u:
+            device.send_message("Hello world")
+            request = u.call_args[0][0]
+            assert request.headers['Authorization'] == 'key=uiopkey'
+
+    def test_gcm_send_multi_message_with_app_id(self):
+        from django.conf import settings
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        device = GCMDevice.objects.create(
+            registration_id="def",
+            application_id="asdfg"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'asdfg':'uiopkey'
+        }
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
+        import json
+        with mock.patch("push_notifications.gcm.urlopen",return_value=StringIO(json.dumps({
+            'failure':[],
+            'canonical_ids':[]
+        }))) as u:
+            GCMDevice.objects.all().send_message("Hello world")
+            assert u.call_count == 1
+            request = u.call_args[0][0]
+            assert request.headers['Authorization'] == 'key=uiopkey'
+
+    def test_gcm_send_multi_message_with_different_app_id(self):
+        from django.conf import settings
+        device = GCMDevice.objects.create(
+            registration_id="abc",
+            application_id="asdfg"
+        )
+        device = GCMDevice.objects.create(
+            registration_id="def",
+            application_id="uiop"
+        )
+        settings.PUSH_NOTIFICATIONS_SETTINGS['GCM_API_KEYS'] = {
+            'asdfg':'asdfgkey',
+            'uiop':'uiopkey'
+        }
+        try:
+            from StringIO import StringIO
+        except ImportError:
+            from io import StringIO
+        import json
+        requests = []
+        def c():
+            def f(r,**kw):
+                requests.append(r)
+                return StringIO(json.dumps({
+                    'failure':[],
+                    'canonical_ids':[]
+                }))
+            return f
+        with mock.patch("push_notifications.gcm.urlopen",new_callable=c) as u:
+            GCMDevice.objects.all().send_message("Hello world")
+            keys = set(r.headers['Authorization'] for r in requests)
+            assert len(keys) == 2
+            assert 'key=asdfgkey' in keys
+            assert 'key=uiopkey' in keys

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -14,6 +14,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "AEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAE",
 			"name": "Apple iPhone 6+",
 			"device_id": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -22,6 +23,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "aeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeae",
 			"name": "Apple iPhone 6+",
 			"device_id": "ffffffffffffffffffffffffffffffff",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -46,6 +48,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "invalid device token contains no hex",
 			"name": "Apple iPhone 6+",
 			"device_id": "ffffffffffffffffffffffffffffake",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 
@@ -56,6 +59,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -67,6 +71,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		serializer.is_valid(raise_exception=True)
 		obj = serializer.save()
@@ -76,6 +81,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 5",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		serializer.is_valid(raise_exception=True)
 		obj = serializer.save()
@@ -85,6 +91,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0xdeadbeaf",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 
 		with self.assertRaises(ValidationError):
@@ -95,6 +102,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x10r",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors, GCM_DRF_INVALID_HEX_ERROR)
@@ -103,7 +111,8 @@ class GCMDeviceSerializerTestCase(TestCase):
 		serializer = GCMDeviceSerializer(data={
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
-			"device_id": "10000000000000000",  # 2**64
+			"device_id": "10000000000000000", # 2**64
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors, GCM_DRF_OUT_OF_RANGE_ERROR)
@@ -116,5 +125,6 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Nexus 5",
 			"device_id": "e87a4e72d634997c",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())

--- a/tests/test_wns.py
+++ b/tests/test_wns.py
@@ -14,13 +14,19 @@ class WNSSendMessageTestCase(TestCase):
 	@mock.patch("push_notifications.wns._wns_send")
 	def test_send_message_calls_wns_send_with_toast(self, mock_method, _):
 		wns_send_message(uri="one", message="test message")
-		mock_method.assert_called_with(uri="one", data="this is expected", wns_type="wns/toast")
+		mock_method.assert_called_with(application_id=None, uri="one", data="this is expected", wns_type="wns/toast")
+
+	@mock.patch("push_notifications.wns._wns_prepare_toast", return_value="this is expected")
+	@mock.patch("push_notifications.wns._wns_send")
+	def test_send_message_calls_wns_send_with_application_id(self, mock_method, _):
+		wns_send_message(uri="one", message="test message", application_id="123456")
+		mock_method.assert_called_with(application_id="123456", uri="one", data="this is expected", wns_type="wns/toast")
 
 	@mock.patch("push_notifications.wns.dict_to_xml_schema", return_value=ET.Element("toast"))
 	@mock.patch("push_notifications.wns._wns_send")
 	def test_send_message_calls_wns_send_with_xml(self, mock_method, _):
 		wns_send_message(uri="one", xml_data={"key": "value"})
-		mock_method.assert_called_with(uri="one", data=b"<toast />", wns_type="wns/toast")
+		mock_method.assert_called_with(application_id=None, uri="one", data=b"<toast />", wns_type="wns/toast")
 
 	def test_send_message_raises_TypeError_if_one_of_the_data_params_arent_filled(self):
 		with self.assertRaises(TypeError):
@@ -40,7 +46,7 @@ class WNSSendBulkMessageTestCase(TestCase):
 	def test_send_bulk_message_calls_send_message(self, mock_method):
 		wns_send_bulk_message(uri_list=["one", ], message="test message")
 		mock_method.assert_called_with(
-			message="test message", raw_data=None, uri="one", xml_data=None
+			application_id=None, message="test message", raw_data=None, uri="one", xml_data=None
 		)
 
 


### PR DESCRIPTION
This is a replacement for the pull requests #247, #259 and #260 with all-in-one commit.

This patch extends the packet to support multiple mobile applications receiving push notifications from one server.

Code, documentation, and tests are provided.

The implementation is backward-compatible, so old-style using of the packet is still available.

Three types of settings are available:

old-style - one mobile application per server instance, compatibility mode
new-style static - multiple (several) mobile applications per server instance, settings file contains direct description of mobile applications credentials (key/certificate), a new mobile application requires settings patching or reloading
new-style dynamic - multiple (a lot) mobile applications per server instance, settings file contains reference to the custom model with mobile application credentials (key/certificate), a new mobile application can be created at runtime without server restart
This patch supercedes and dismisses (makes irrelevant) patch #226

This patch solves #130
