### PR TITLE
Allow send_message to set thread-id for APNS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,12 +107,14 @@ GCM and APNS services have slightly different semantics. The app tries to offer 
 	device = APNSDevice.objects.get(registration_id=apns_token)
 	device.send_message("You've got mail") # Alert message may only be sent as text.
 	device.send_message(None, badge=5) # No alerts but with badge.
-	device.send_message(None, badge=1, extra={"foo": "bar"}) # Silent message with badge and added custom data.
+	device.send_message(None, content_available=1, extra={"foo": "bar"}) # Silent message with custom data.
+	device.send_message("alert" : {"title" : "Game Request", "body" : "Bob wants to play poker", extra={"foo": "bar"}) # alert with title and body.
 
 .. note::
 	APNS does not support sending payloads that exceed 2048 bytes (increased from 256 in 2014).
 	The message is only one part of the payload, if
 	once constructed the payload exceeds the maximum size, an ``APNSDataOverflow`` exception will be raised before anything is sent.
+  Reference: `Apple Payload Documentation <https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH10-SW1>`_
 
 Sending messages in bulk
 ------------------------

--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,9 @@ GCM and APNS services have slightly different semantics. The app tries to offer 
 	device.send_message("You've got mail") # Alert message may only be sent as text.
 	device.send_message(None, badge=5) # No alerts but with badge.
 	device.send_message(None, content_available=1, extra={"foo": "bar"}) # Silent message with custom data.
-	device.send_message("alert" : {"title" : "Game Request", "body" : "Bob wants to play poker", extra={"foo": "bar"}) # alert with title and body.
+	# alert with title and body.
+	device.send_message("alert" : {"title" : "Game Request", "body" : "Bob wants to play poker", extra={"foo": "bar"})
+	device.send_message("Hello again", thread_id="123" extra={"foo": "bar"}) # set thread-id to allow iOS to merge notifications
 
 .. note::
 	APNS does not support sending payloads that exceed 2048 bytes (increased from 256 in 2014).

--- a/push_notifications/apns.py
+++ b/push_notifications/apns.py
@@ -141,7 +141,7 @@ def _apns_check_errors(sock):
 def _apns_send(
 	token, alert, badge=None, sound=None, category=None, content_available=False,
 	action_loc_key=None, loc_key=None, loc_args=[], extra={}, identifier=0,
-	expiration=None, priority=10, socket=None, certfile=None, mutable_content=False
+	expiration=None, priority=10, socket=None, certfile=None, mutable_content=False, thread_id=None
 ):
 	data = {}
 	aps_data = {}
@@ -174,6 +174,9 @@ def _apns_send(
 
 	if mutable_content:
 		aps_data["mutable-content"] = 1
+
+	if thread_id:
+		aps_data["thread-id"] = thread_id
 
 	data["aps"] = aps_data
 	data.update(extra)

--- a/tests/test_apns_push_payload.py
+++ b/tests/test_apns_push_payload.py
@@ -16,6 +16,30 @@ class APNSPushPayloadTest(TestCase):
 				b'{"aps":{"alert":"Hello world","badge":1,"sound":"chime"},"custom_data":12345}',
 				0, 3, 10)
 
+	def test_push_payload_with_thread_id(self):
+		socket = mock.MagicMock()
+		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+			_apns_send(
+				"123", "Hello world", thread_id="565", sound="chime",
+				extra={"custom_data": 12345}, expiration=3, socket=socket
+			)
+			p.assert_called_once_with(
+				"123",
+				b'{"aps":{"alert":"Hello world","sound":"chime","thread-id":"565"},"custom_data":12345}',
+				0, 3, 10)
+
+	def test_push_payload_with_alert_dict(self):
+		socket = mock.MagicMock()
+		with mock.patch("push_notifications.apns._apns_pack_frame") as p:
+			_apns_send(
+				"123", alert={'title':'t1', 'body':'b1'}, sound="chime",
+				extra={"custom_data": 12345}, expiration=3, socket=socket
+			)
+			p.assert_called_once_with(
+				"123",
+				b'{"aps":{"alert":{"body":"b1","title":"t1"},"sound":"chime"},"custom_data":12345}',
+				0, 3, 10)
+
 	def test_localised_push_with_empty_body(self):
 		socket = mock.MagicMock()
 		with mock.patch("push_notifications.apns._apns_pack_frame") as p:


### PR DESCRIPTION
Add the thread-id keyword from the [Apple Payload Guide](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1). 

Includes tests and documentation in the README.