### PR TITLE
Replace distutils with setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os.path
 import push_notifications
-from distutils.core import setup
+from setuptools import setup
 
 README = open(os.path.join(os.path.dirname(__file__), "README.rst")).read()
 


### PR DESCRIPTION
`distutils.core.setup` does not support `python setup.py develop`. Replace with the standard `setuptools.setup` variant makes developing and integrating multiple python modules easier. I also thought distutils was deprecated in favor of setuptools.