### PR TITLE
Enable multiple application support

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -33,7 +33,10 @@ class HexIntegerField(IntegerField):
 # Serializers
 class DeviceSerializerMixin(ModelSerializer):
 	class Meta:
-		fields = ("id", "name", "registration_id", "device_id", "active", "date_created")
+		fields = (
+			"id", "name", "application_id", "registration_id", "device_id",
+			"active", "date_created"
+		)
 		read_only_fields = ("date_created",)
 
 		# See https://github.com/tomchristie/django-rest-framework/issues/1101

--- a/push_notifications/conf/__init__.py
+++ b/push_notifications/conf/__init__.py
@@ -1,0 +1,21 @@
+from django.utils.module_loading import import_string
+from .app import AppConfig  # noqa: F401
+from .appmodel import AppModelConfig  # noqa: F401
+from .legacy import LegacyConfig  # noqa: F401
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+
+
+manager = None
+
+
+def get_manager(reload=False):
+	global manager
+
+	if not manager or reload is True:
+		manager = import_string(SETTINGS["CONFIG"])()
+
+	return manager
+
+
+# implementing get_manager as a function allows tests to reload settings
+get_manager()

--- a/push_notifications/conf/app.py
+++ b/push_notifications/conf/app.py
@@ -1,0 +1,284 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.six import string_types
+from .base import BaseConfig, check_apns_certificate
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+
+SETTING_MISMATCH = (
+	"Application '{application_id}' ({platform}) does not support the setting '{setting}'."
+)
+
+
+# code can be "missing" or "invalid"
+BAD_PLATFORM = (
+	"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['{application_id}']['PLATFORM']"
+	" is {code}. Must be one of: {platforms}."
+)
+
+UNKNOWN_PLATFORM = (
+	"Unknown Platform: {platform}. Must be one of: {platforms}."
+)
+
+MISSING_SETTING = (
+	"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['{application_id}']['{setting}'] is missing."
+)
+
+PLATFORMS = [
+	"APNS",
+	"FCM",
+	"GCM",
+	"WNS"
+]
+
+# Settings that all applications must have
+REQUIRED_SETTINGS = [
+	"PLATFORM",
+]
+
+# Settings that an application may have to enable optional features
+# these settings are stubs for registry support and have no effect on the operation
+# of the application at this time.
+OPTIONAL_SETTINGS = [
+	"APPLICATION_GROUP",
+	"APPLICATION_SECRET",
+]
+
+APNS_REQUIRED_SETTINGS = ["CERTIFICATE"]
+
+APNS_OPTIONAL_SETTINGS = [
+	"USE_SANDBOX", "USE_ALTERNATIVE_PORT", "TOPIC"
+]
+
+FCM_REQUIRED_SETTINGS = GCM_REQUIRED_SETTINGS = ["API_KEY"]
+FCM_OPTIONAL_SETTINGS = GCM_OPTIONAL_SETTINGS = [
+	"POST_URL", "MAX_RECIPIENTS", "ERROR_TIMEOUT"
+]
+
+WNS_REQUIRED_SETTINGS = ["PACKAGE_SECURITY_ID", "SECRET_KEY"]
+
+WNS_OPTIONAL_SETTINGS = ["WNS_ACCESS_URL"]
+
+
+class AppConfig(BaseConfig):
+	"""Supports any number of push notification enabled applications."""
+
+	def __init__(self, settings=None):
+		# supports overriding the settings to be loaded. Will load from ..settings by default.
+		self._settings = settings or SETTINGS
+
+		# initialize APPLICATIONS to an empty collection
+		self._settings.setdefault("APPLICATIONS", {})
+
+		# validate application configurations
+		self._validate_applications(self._settings["APPLICATIONS"])
+
+	def _validate_applications(self, apps):
+		"""Validate the application collection"""
+		for application_id, application_config in apps.items():
+			self._validate_config(application_id, application_config)
+
+			application_config["APPLICATION_ID"] = application_id
+
+	def _validate_config(self, application_id, application_config):
+		platform = application_config.get("PLATFORM", None)
+
+		# platform is not present
+		if platform is None:
+			raise ImproperlyConfigured(
+				BAD_PLATFORM.format(
+					application_id=application_id,
+					code="required",
+					platforms=", ".join(PLATFORMS)
+				)
+			)
+
+		# platform is not a valid choice from PLATFORMS
+		if platform not in PLATFORMS:
+			raise ImproperlyConfigured(
+				BAD_PLATFORM.format(
+					application_id=application_id,
+					code="invalid",
+					platforms=", ".join(PLATFORMS)
+				)
+			)
+
+		validate_fn = "_validate_{platform}_config".format(platform=platform).lower()
+
+		if hasattr(self, validate_fn):
+			getattr(self, validate_fn)(application_id, application_config)
+		else:
+			raise ImproperlyConfigured(
+				UNKNOWN_PLATFORM.format(
+					platform=platform,
+					platforms=", ".join(PLATFORMS)
+				)
+			)
+
+	def _validate_apns_config(self, application_id, application_config):
+		allowed = REQUIRED_SETTINGS + OPTIONAL_SETTINGS + APNS_REQUIRED_SETTINGS + \
+			APNS_OPTIONAL_SETTINGS
+
+		self._validate_allowed_settings(application_id, application_config, allowed)
+		self._validate_required_settings(
+			application_id, application_config, APNS_REQUIRED_SETTINGS
+		)
+
+		# determine/set optional values
+		application_config.setdefault("USE_SANDBOX", False)
+		application_config.setdefault("USE_ALTERNATIVE_PORT", False)
+		application_config.setdefault("TOPIC", "")
+
+		self._validate_apns_certificate(application_config["CERTIFICATE"])
+
+	def _validate_apns_certificate(self, certfile):
+		"""Validate the APNS certificate at startup."""
+
+		try:
+			with open(certfile, "r") as f:
+				content = f.read()
+				check_apns_certificate(content)
+		except Exception as e:
+			msg = "The APNS certificate file at %r is not readable: %s" % (certfile, e)
+			raise ImproperlyConfigured(msg)
+
+	def _validate_fcm_config(self, application_id, application_config):
+		allowed = REQUIRED_SETTINGS + OPTIONAL_SETTINGS + FCM_REQUIRED_SETTINGS + \
+			FCM_OPTIONAL_SETTINGS
+
+		self._validate_allowed_settings(application_id, application_config, allowed)
+		self._validate_required_settings(
+			application_id, application_config, FCM_REQUIRED_SETTINGS
+		)
+
+		application_config.setdefault("POST_URL", "https://fcm.googleapis.com/fcm/send")
+		application_config.setdefault("MAX_RECIPIENTS", 1000)
+		application_config.setdefault("ERROR_TIMEOUT", None)
+
+	def _validate_gcm_config(self, application_id, application_config):
+		allowed = REQUIRED_SETTINGS + OPTIONAL_SETTINGS + GCM_REQUIRED_SETTINGS + \
+			GCM_OPTIONAL_SETTINGS
+
+		self._validate_allowed_settings(application_id, application_config, allowed)
+		self._validate_required_settings(
+			application_id, application_config, GCM_REQUIRED_SETTINGS
+		)
+
+		application_config.setdefault("POST_URL", "https://android.googleapis.com/gcm/send")
+		application_config.setdefault("MAX_RECIPIENTS", 1000)
+		application_config.setdefault("ERROR_TIMEOUT", None)
+
+	def _validate_wns_config(self, application_id, application_config):
+		allowed = REQUIRED_SETTINGS + OPTIONAL_SETTINGS + WNS_REQUIRED_SETTINGS + \
+			WNS_OPTIONAL_SETTINGS
+
+		self._validate_allowed_settings(application_id, application_config, allowed)
+		self._validate_required_settings(
+			application_id, application_config, WNS_REQUIRED_SETTINGS
+		)
+
+		application_config.setdefault("WNS_ACCESS_URL", "https://login.live.com/accesstoken.srf")
+
+	def _validate_allowed_settings(self, application_id, application_config, allowed_settings):
+		"""Confirm only allowed settings are present."""
+
+		for setting_key in application_config.keys():
+			if setting_key not in allowed_settings:
+				raise ImproperlyConfigured(
+					"Platform {}, app {} does not support the setting: {}.".format(
+						application_config["PLATFORM"], application_id, setting_key
+					)
+				)
+
+	def _validate_required_settings(
+		self, application_id, application_config, required_settings
+	):
+		"""All required keys must be present"""
+
+		for setting_key in required_settings:
+			if setting_key not in application_config.keys():
+				raise ImproperlyConfigured(
+					MISSING_SETTING.format(
+						application_id=application_id, setting=setting_key
+					)
+				)
+
+	def _get_application_settings(self, application_id, platform, settings_key):
+		"""Walks through PUSH_NOTIFICATIONS_SETTINGS to find the correct setting
+		value or dies trying"""
+
+		if not application_id:
+			conf_cls = "push_notifications.conf.AppConfig"
+			raise ImproperlyConfigured(
+				"{} requires the application_id be specified at all times.".format(conf_cls)
+			)
+
+		# verify that the application config exists
+		app_config = self._settings.get("APPLICATIONS").get(application_id, None)
+		if app_config is None:
+			raise ImproperlyConfigured(
+				"No application configured with application_id: {}.".format(application_id)
+			)
+
+		# fetch a setting for the incorrect type of platform
+		if app_config.get("PLATFORM") != platform:
+			raise ImproperlyConfigured(
+				SETTING_MISMATCH.format(
+					application_id=application_id,
+					platform=app_config.get("PLATFORM"),
+					setting=settings_key
+				)
+			)
+
+		# finally, try to fetch the setting
+		if settings_key not in app_config:
+			raise ImproperlyConfigured(
+				MISSING_SETTING.format(
+					application_id=application_id, setting=settings_key
+				)
+			)
+
+		return app_config.get(settings_key)
+
+	def get_gcm_api_key(self, application_id=None):
+		return self._get_application_settings(application_id, "GCM", "API_KEY")
+
+	def get_fcm_api_key(self, application_id=None):
+		return self._get_application_settings(application_id, "FCM", "API_KEY")
+
+	def get_post_url(self, cloud_type, application_id=None):
+		return self._get_application_settings(application_id, cloud_type, "POST_URL")
+
+	def get_error_timeout(self, cloud_type, application_id=None):
+		return self._get_application_settings(application_id, cloud_type, "ERROR_TIMEOUT")
+
+	def get_max_recipients(self, cloud_type, application_id=None):
+		return self._get_application_settings(application_id, cloud_type, "MAX_RECIPIENTS")
+
+	def get_apns_certificate(self, application_id=None):
+		r = self._get_application_settings(application_id, "APNS", "CERTIFICATE")
+		if not isinstance(r, string_types):
+			# probably the (Django) file, and file path should be got
+			if hasattr(r, "path"):
+				return r.path
+			elif (hasattr(r, "has_key") or hasattr(r, "__contains__")) and "path" in r:
+				return r["path"]
+			else:
+				raise ImproperlyConfigured(
+					"The APNS certificate settings value should be a string, or "
+					"should have a 'path' attribute or key"
+				)
+		return r
+
+	def get_apns_use_sandbox(self, application_id=None):
+		return self._get_application_settings(application_id, "APNS", "USE_SANDBOX")
+
+	def get_apns_use_alternative_port(self, application_id=None):
+		return self._get_application_settings(application_id, "APNS", "USE_ALTERNATIVE_PORT")
+
+	def get_apns_topic(self, application_id=None):
+		return self._get_application_settings(application_id, "APNS", "TOPIC")
+
+	def get_wns_package_security_id(self, application_id=None):
+		return self._get_application_settings(application_id, "WNS", "PACKAGE_SECURITY_ID")
+
+	def get_wns_secret_key(self, application_id=None):
+		return self._get_application_settings(application_id, "WNS", "SECRET_KEY")

--- a/push_notifications/conf/appmodel.py
+++ b/push_notifications/conf/appmodel.py
@@ -1,0 +1,10 @@
+from .base import BaseConfig
+
+
+class AppModelConfig(BaseConfig):
+	"""Future home of the Application Model conf adapter
+
+	Supports multiple applications in the database.
+	"""
+
+	pass

--- a/push_notifications/conf/base.py
+++ b/push_notifications/conf/base.py
@@ -1,0 +1,55 @@
+from django.core.exceptions import ImproperlyConfigured
+
+
+class BaseConfig(object):
+	def get_apns_certificate(self, application_id=None):
+		raise NotImplementedError
+
+	def get_apns_use_sandbox(self, application_id=None):
+		raise NotImplementedError
+
+	def get_apns_use_alternative_port(self, application_id=None):
+		raise NotImplementedError
+
+	def get_fcm_api_key(self, application_id=None):
+		raise NotImplementedError
+
+	def get_gcm_api_key(self, application_id=None):
+		raise NotImplementedError
+
+	def get_wns_package_security_id(self, application_id=None):
+		raise NotImplementedError
+
+	def get_wns_secret_key(self, application_id=None):
+		raise NotImplementedError
+
+	def get_post_url(self, cloud_type, application_id=None):
+		raise NotImplementedError
+
+	def get_error_timeout(self, cloud_type, application_id=None):
+		raise NotImplementedError
+
+	def get_max_recipients(self, cloud_type, application_id=None):
+		raise NotImplementedError
+
+	def get_applications(self):
+		"""Returns a collection containing the configured applications."""
+
+		raise NotImplementedError
+
+
+def check_apns_certificate(ss):
+	mode = "start"
+	for s in ss.split("\n"):
+		if mode == "start":
+			if "BEGIN RSA PRIVATE KEY" in s or "BEGIN PRIVATE KEY" in s:
+				mode = "key"
+		elif mode == "key":
+			if "END RSA PRIVATE KEY" in s or "END PRIVATE KEY" in s:
+				mode = "end"
+				break
+			elif s.startswith("Proc-Type") and "ENCRYPTED" in s:
+				raise ImproperlyConfigured("Encrypted APNS private keys are not supported")
+
+	if mode != "end":
+		raise ImproperlyConfigured("The APNS certificate doesn't contain a private key")

--- a/push_notifications/conf/legacy.py
+++ b/push_notifications/conf/legacy.py
@@ -1,0 +1,120 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.six import string_types
+from .base import BaseConfig
+from ..settings import PUSH_NOTIFICATIONS_SETTINGS as SETTINGS
+
+
+__all__ = [
+	"LegacyConfig"
+]
+
+
+class LegacyConfig(BaseConfig):
+	def _get_application_settings(self, application_id, settings_key, error_message):
+		"""Legacy behaviour"""
+
+		if not application_id:
+			value = SETTINGS.get(settings_key, None)  # do we need a NO_OP?
+			if value is None:
+				raise ImproperlyConfigured(error_message)
+			return value
+		else:
+			msg = (
+				"LegacySettings does not support application_id. To enable "
+				"multiple application support, use push_notifications.conf.AppSettings."
+			)
+			raise ImproperlyConfigured(msg)
+
+	def get_gcm_api_key(self, application_id=None):
+		msg = (
+			"Set PUSH_NOTIFICATIONS_SETTINGS[\"GCM_API_KEY\"] to send messages through GCM."
+		)
+		return self._get_application_settings(application_id, "GCM_API_KEY", msg)
+
+	def get_fcm_api_key(self, application_id=None):
+		msg = (
+			"Set PUSH_NOTIFICATIONS_SETTINGS[\"FCM_API_KEY\"] to send messages through FCM."
+		)
+		return self._get_application_settings(application_id, "FCM_API_KEY", msg)
+
+	def get_post_url(self, cloud_type, application_id=None):
+		key = "{}_API_KEY".format(cloud_type)
+		msg = (
+			"Set PUSH_NOTIFICATIONS_SETTINGS[\"{}\"] to send messages through {}.".format(
+				key, cloud_type
+			)
+		)
+		return self._get_application_settings(application_id, key, msg)
+
+	def get_error_timeout(self, cloud_type, application_id=None):
+		key = "{}_ERROR_TIMEOUT".format(cloud_type)
+		msg = (
+			"Set PUSH_NOTIFICATIONS_SETTINGS[\"{}\"] to send messages through {}.".format(
+				key, cloud_type
+			)
+		)
+		return self._get_application_settings(application_id, key, msg)
+
+	def get_max_recipients(self, cloud_type, application_id=None):
+		key = "{}_MAX_RECIPIENTS".format(cloud_type)
+		msg = (
+			"Set PUSH_NOTIFICATIONS_SETTINGS[\"{}\"] to send messages through {}.".format(
+				key, cloud_type
+			)
+		)
+		return self._get_application_settings(application_id, key, msg)
+
+	def get_apns_certificate(self, application_id=None):
+		r = self._get_application_settings(
+			application_id, "APNS_CERTIFICATE",
+			"You need to setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		)
+		if not isinstance(r, string_types):
+			# probably the (Django) file, and file path should be got
+			if hasattr(r, "path"):
+				return r.path
+			elif (hasattr(r, "has_key") or hasattr(r, "__contains__")) and "path" in r:
+				return r["path"]
+			else:
+				msg = (
+					"The APNS certificate settings value should be a string, or "
+					"should have a 'path' attribute or key"
+				)
+				raise ImproperlyConfigured(msg)
+		return r
+
+	def get_apns_use_sandbox(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "APNS_USE_SANDBOX", msg)
+
+	def get_apns_use_alternative_port(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "APNS_USE_ALTERNATIVE_PORT", msg)
+
+	def get_apns_topic(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "APNS_TOPIC", msg)
+
+	def get_apns_host(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "APNS_HOST", msg)
+
+	def get_apns_port(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "APNS_PORT", msg)
+
+	def get_apns_feedback_host(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "APNS_FEEDBACK_HOST", msg)
+
+	def get_apns_feedback_port(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "APNS_FEEDBACK_PORT", msg)
+
+	def get_wns_package_security_id(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "WNS_PACKAGE_SECURITY_ID", msg)
+
+	def get_wns_secret_key(self, application_id=None):
+		msg = "Setup PUSH_NOTIFICATIONS_SETTINGS properly to send messages"
+		return self._get_application_settings(application_id, "WNS_SECRET_KEY", msg)

--- a/push_notifications/migrations/0005_applicationid.py
+++ b/push_notifications/migrations/0005_applicationid.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('push_notifications', '0004_fcm'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='apnsdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='gcmdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='wnsdevice',
+            name='application_id',
+            field=models.CharField(help_text='Opaque application identity, should be filled in for multiple key/certificate access', max_length=64, null=True, verbose_name='Application ID', blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/push_notifications/settings.py
+++ b/push_notifications/settings.py
@@ -3,6 +3,10 @@ from django.conf import settings
 
 PUSH_NOTIFICATIONS_SETTINGS = getattr(settings, "PUSH_NOTIFICATIONS_SETTINGS", {})
 
+PUSH_NOTIFICATIONS_SETTINGS.setdefault(
+	"CONFIG", "push_notifications.conf.LegacyConfig"
+)
+
 # GCM
 PUSH_NOTIFICATIONS_SETTINGS.setdefault(
 	"GCM_POST_URL", "https://android.googleapis.com/gcm/send"

--- a/push_notifications/utils.py
+++ b/push_notifications/utils.py
@@ -3,5 +3,5 @@ from .apns import apns_fetch_inactive_ids
 
 # This is an APNS-only function right now, but maybe GCM will implement it
 # in the future.  But the definition of 'expired' may not be the same.
-def get_expired_tokens(cerfile=None):
-	return apns_fetch_inactive_ids(cerfile)
+def get_expired_tokens(application_id):
+	return apns_fetch_inactive_ids(application_id)

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,9 @@ classifiers =
 
 [options]
 packages = find:
-install_requires = Django>=1.8
+install_requires =
+	apns2
+	Django>=1.8
 
 [bdist_wheel]
 universal = 1

--- a/tests/test_apns_models.py
+++ b/tests/test_apns_models.py
@@ -1,7 +1,7 @@
 from apns2.client import NotificationPriority
 from apns2.errors import BadTopic, PayloadTooLarge, Unregistered
-
-from django.test import TestCase
+from django.conf import settings
+from django.test import override_settings, TestCase
 from push_notifications.apns import APNSError
 from push_notifications.models import APNSDevice
 
@@ -14,8 +14,14 @@ class APNSModelTestCase(TestCase):
 		for device in devices:
 			APNSDevice.objects.create(registration_id=device)
 
+	@override_settings()
 	def test_apns_send_bulk_message(self):
 		self._create_devices(["abc", "def"])
+
+		# legacy conf manager requires a value
+		settings.PUSH_NOTIFICATIONS_SETTINGS.update({
+			"APNS_CERTIFICATE": "/path/to/apns/certificate.pem"
+		})
 
 		with mock.patch("apns2.client.init_context"):
 			with mock.patch("apns2.client.APNsClient.connect"):

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -1,0 +1,351 @@
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+from push_notifications.conf import AppConfig
+
+
+class AppConfigTestCase(TestCase):
+	def test_application_id_required(self):
+		"""Using AppConfig without an application_id raises ImproperlyConfigured."""
+
+		manager = AppConfig()
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			manager._get_application_settings(None, None, None)
+
+		self.assertEqual(
+			str(ic.exception),
+			"push_notifications.conf.AppConfig requires the application_id be "
+			"specified at all times."
+		)
+
+	def test_application_not_found(self):
+		"""Using AppConfig with an application_id that does not exist raises
+		ImproperlyConfigured."""
+
+		application_id = "my_fcm_app"
+
+		manager = AppConfig()
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			manager._get_application_settings(application_id, "FCM", "API_KEY")
+
+		self.assertEqual(
+			str(ic.exception),
+			"No application configured with application_id: {}.".format(application_id)
+		)
+
+	def test_platform_configured(self):
+		"""Using AppConfig with an application config that does not define PLATFORM
+		raises ImproperlyConfigured."""
+
+		application_id = "my_fcm_app"
+
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				application_id: {}
+			}
+		}
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			AppConfig(PUSH_SETTINGS)
+
+		self.assertEqual(
+			str(ic.exception),
+			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['{}']['PLATFORM'] is required."
+			" Must be one of: APNS, FCM, GCM, WNS.".format(application_id)
+		)
+
+	def test_platform_invalid(self):
+		"""Using AppConfig with an invalid platform raises ImproperlyConfigured."""
+
+		application_id = "my_fcm_app"
+
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				application_id: {
+					"PLATFORM": "XXX"
+				}
+			}
+		}
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			AppConfig(PUSH_SETTINGS)
+
+		self.assertEqual(
+			str(ic.exception),
+			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['{}']['PLATFORM'] is invalid."
+			" Must be one of: APNS, FCM, GCM, WNS.".format(application_id)
+		)
+
+	def test_platform_invalid_setting(self):
+		"""Fetching application settings for the wrong platform raises ImproperlyConfigured."""
+
+		application_id = "my_fcm_app"
+
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				application_id: {
+					"PLATFORM": "FCM",
+					"API_KEY": "[my_api_key]"
+				}
+			}
+		}
+
+		manager = AppConfig(PUSH_SETTINGS)
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			manager._get_application_settings(application_id, "APNS", "CERTIFICATE")
+
+		self.assertEqual(
+			str(ic.exception),
+			"Application 'my_fcm_app' (FCM) does not support the setting 'CERTIFICATE'."
+		)
+
+	def test_missing_setting(self):
+		"""Missing application settings raises ImproperlyConfigured."""
+
+		application_id = "my_fcm_app"
+
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				application_id: {
+					"PLATFORM": "FCM"
+				}
+			}
+		}
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			AppConfig(PUSH_SETTINGS)
+
+		self.assertEqual(
+			str(ic.exception),
+			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['my_fcm_app']['API_KEY'] is missing."
+		)
+
+	def test_validate_apns_config(self):
+		"""Verify the settings for APNS platform."""
+
+		path = os.path.join(os.path.dirname(__file__), "test_data", "good_revoked.pem")
+
+		#
+		# all settings specified, required and optional, does not raise an error.
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_apns_app": {
+					"PLATFORM": "APNS",
+					"CERTIFICATE": path,
+					"USE_ALTERNATIVE_PORT": True,
+					"USE_SANDBOX": True
+				}
+			}
+		}
+		AppConfig(PUSH_SETTINGS)
+
+		#
+		# missing required settings
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_apns_app": {
+					"PLATFORM": "APNS",
+				}
+			}
+		}
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			AppConfig(PUSH_SETTINGS)
+
+		self.assertEqual(
+			str(ic.exception),
+			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['my_apns_app']['CERTIFICATE'] is missing."
+		)
+
+		#
+		# all optional settings have default values
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_apns_app": {
+					"PLATFORM": "APNS",
+					"CERTIFICATE": path,
+				}
+			}
+		}
+
+		manager = AppConfig(PUSH_SETTINGS)
+		app_config = manager._settings["APPLICATIONS"]["my_apns_app"]
+
+		assert app_config["USE_SANDBOX"] is False
+		assert app_config["USE_ALTERNATIVE_PORT"] is False
+
+	def test_get_allowed_settings_fcm(self):
+		"""Verify the settings allowed for FCM platform."""
+
+		#
+		# all settings specified, required and optional, does not raise an error.
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_fcm_app": {
+					"PLATFORM": "FCM",
+					"API_KEY": "...",
+					"POST_URL": "...",
+					"MAX_RECIPIENTS": "...",
+					"ERROR_TIMEOUT": "...",
+				}
+			}
+		}
+		AppConfig(PUSH_SETTINGS)
+
+		#
+		# missing required settings
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_fcm_app": {
+					"PLATFORM": "FCM",
+				}
+			}
+		}
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			AppConfig(PUSH_SETTINGS)
+
+		self.assertEqual(
+			str(ic.exception),
+			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['my_fcm_app']['API_KEY'] is missing."
+		)
+
+		#
+		# all optional settings have default values
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_fcm_app": {
+					"PLATFORM": "FCM",
+					"API_KEY": "...",
+				}
+			}
+		}
+
+		manager = AppConfig(PUSH_SETTINGS)
+		app_config = manager._settings["APPLICATIONS"]["my_fcm_app"]
+
+		assert app_config["POST_URL"] == "https://fcm.googleapis.com/fcm/send"
+		assert app_config["MAX_RECIPIENTS"] == 1000
+		assert app_config["ERROR_TIMEOUT"] is None
+
+	def test_get_allowed_settings_gcm(self):
+		"""Verify the settings allowed for GCM platform."""
+
+		#
+		# all settings specified, required and optional, does not raise an error.
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_gcm_app": {
+					"PLATFORM": "GCM",
+					"API_KEY": "...",
+					"POST_URL": "...",
+					"MAX_RECIPIENTS": "...",
+					"ERROR_TIMEOUT": "...",
+				}
+			}
+		}
+		AppConfig(PUSH_SETTINGS)
+
+		#
+		# missing required settings
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_gcm_app": {
+					"PLATFORM": "GCM",
+				}
+			}
+		}
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			AppConfig(PUSH_SETTINGS)
+
+		self.assertEqual(
+			str(ic.exception),
+			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['my_gcm_app']['API_KEY'] is missing."
+		)
+
+		#
+		# all optional settings have default values
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_gcm_app": {
+					"PLATFORM": "GCM",
+					"API_KEY": "...",
+				}
+			}
+		}
+
+		manager = AppConfig(PUSH_SETTINGS)
+		app_config = manager._settings["APPLICATIONS"]["my_gcm_app"]
+
+		assert app_config["POST_URL"] == "https://android.googleapis.com/gcm/send"
+		assert app_config["MAX_RECIPIENTS"] == 1000
+		assert app_config["ERROR_TIMEOUT"] is None
+
+	def test_get_allowed_settings_wns(self):
+		"""Verify the settings allowed for WNS platform."""
+
+		#
+		# all settings specified, required and optional, does not raise an error.
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_wns_app": {
+					"PLATFORM": "WNS",
+					"PACKAGE_SECURITY_ID": "...",
+					"SECRET_KEY": "...",
+					"WNS_ACCESS_URL": "...",
+				}
+			}
+		}
+		AppConfig(PUSH_SETTINGS)
+
+		#
+		# missing required settings
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_wns_app": {
+					"PLATFORM": "WNS",
+				}
+			}
+		}
+
+		with self.assertRaises(ImproperlyConfigured) as ic:
+			AppConfig(PUSH_SETTINGS)
+
+		self.assertEqual(
+			str(ic.exception),
+			"PUSH_NOTIFICATIONS_SETTINGS.APPLICATIONS['my_wns_app']"
+			"['PACKAGE_SECURITY_ID'] is missing."
+		)
+
+		#
+		# all optional settings have default values
+		#
+		PUSH_SETTINGS = {
+			"APPLICATIONS": {
+				"my_wns_app": {
+					"PLATFORM": "WNS",
+					"PACKAGE_SECURITY_ID": "...",
+					"SECRET_KEY": "...",
+				}
+			}
+		}
+
+		manager = AppConfig(PUSH_SETTINGS)
+		app_config = manager._settings["APPLICATIONS"]["my_wns_app"]
+
+		assert app_config["WNS_ACCESS_URL"] == "https://login.live.com/accesstoken.srf"

--- a/tests/test_gcm_push_payload.py
+++ b/tests/test_gcm_push_payload.py
@@ -12,7 +12,19 @@ class GCMPushPayloadTest(TestCase):
 			send_message("abc", {"message": "Hello world"}, "FCM")
 			p.assert_called_once_with(
 				b'{"notification":{"body":"Hello world"},"registration_ids":["abc"]}',
-				"application/json")
+				"application/json", application_id=None)
+
+	def test_push_payload_with_app_id(self):
+		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
+			send_message("abc", {"message": "Hello world"}, "GCM")
+			p.assert_called_once_with(
+				b'{"data":{"message":"Hello world"},"registration_ids":["abc"]}',
+				"application/json", application_id=None)
+		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
+			send_message("abc", {"message": "Hello world"}, "GCM")
+			p.assert_called_once_with(
+				b'{"data":{"message":"Hello world"},"registration_ids":["abc"]}',
+				"application/json", application_id=None)
 
 	def test_fcm_push_payload_params(self):
 		with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_JSON) as p:
@@ -26,21 +38,21 @@ class GCMPushPayloadTest(TestCase):
 				b'{"data":{"other":"misc"},"delay_while_idle":true,'
 				b'"notification":{"body":"Hello world","title":"Push notification"},'
 				b'"registration_ids":["abc"],"time_to_live":3600}',
-				"application/json")
+				"application/json", application_id=None)
 
 	def test_fcm_push_payload_many(self):
 		with mock.patch("push_notifications.gcm._fcm_send", return_value=GCM_JSON_MULTIPLE) as p:
 			send_bulk_message(["abc", "123"], {"message": "Hello world"}, "FCM")
 			p.assert_called_once_with(
 				b'{"notification":{"body":"Hello world"},"registration_ids":["abc","123"]}',
-				"application/json")
+				"application/json", application_id=None)
 
 	def test_gcm_push_payload(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
 			send_message("abc", {"message": "Hello world"}, "GCM")
 			p.assert_called_once_with(
 				b'{"data":{"message":"Hello world"},"registration_ids":["abc"]}',
-				"application/json")
+				"application/json", application_id=None)
 
 	def test_gcm_push_payload_params(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON) as p:
@@ -51,11 +63,12 @@ class GCMPushPayloadTest(TestCase):
 			p.assert_called_once_with(
 				b'{"data":{"message":"Hello world"},"delay_while_idle":true,'
 				b'"registration_ids":["abc"],"time_to_live":3600}',
-				"application/json")
+				"application/json", application_id=None)
 
 	def test_gcm_push_payload_many(self):
 		with mock.patch("push_notifications.gcm._gcm_send", return_value=GCM_JSON_MULTIPLE) as p:
 			send_bulk_message(["abc", "123"], {"message": "Hello world"}, "GCM")
 			p.assert_called_once_with(
 				b'{"data":{"message":"Hello world"},"registration_ids":["abc","123"]}',
-				"application/json")
+				"application/json",
+				application_id=None)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -42,7 +42,9 @@ class GCMModelTestCase(TestCase):
 				json.dumps({
 					"data": {"message": "Hello world"},
 					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_gcm_send_message_extra(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="GCM")
@@ -55,7 +57,9 @@ class GCMModelTestCase(TestCase):
 					"collapse_key": "test_key",
 					"data": {"message": "Hello world", "foo": "bar"},
 					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_gcm_send_message_collapse_key(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="GCM")
@@ -68,7 +72,9 @@ class GCMModelTestCase(TestCase):
 					"data": {"message": "Hello world"},
 					"registration_ids": ["abc"],
 					"collapse_key": "test_key"
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_gcm_send_message_to_multiple_devices(self):
 		self._create_devices(["abc", "abc1"])
@@ -81,7 +87,9 @@ class GCMModelTestCase(TestCase):
 				json.dumps({
 					"data": {"message": "Hello world"},
 					"registration_ids": ["abc", "abc1"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_gcm_send_message_active_devices(self):
 		GCMDevice.objects.create(registration_id="abc", active=True, cloud_message_type="GCM")
@@ -95,7 +103,9 @@ class GCMModelTestCase(TestCase):
 				json.dumps({
 					"data": {"message": "Hello world"},
 					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_gcm_send_message_collapse_to_multiple_devices(self):
 		self._create_devices(["abc", "abc1"])
@@ -109,7 +119,9 @@ class GCMModelTestCase(TestCase):
 						"collapse_key": "test_key",
 						"data": {"message": "Hello world"},
 						"registration_ids": ["abc", "abc1"]
-					}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+					}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+					"application/json", application_id=None
+				)
 
 	def test_gcm_send_message_to_single_device_with_error(self):
 		# these errors are device specific, device.active will be set false
@@ -212,7 +224,7 @@ class GCMModelTestCase(TestCase):
 			reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
 			send_bulk_message(reg_ids, {"message": "Hello World"}, "GCM")
 			p.assert_called_once_with(
-				[u"abc", u"abc1"], {"message": "Hello World"}, cloud_type="GCM"
+				[u"abc", u"abc1"], {"message": "Hello World"}, cloud_type="GCM", application_id=None
 			)
 
 	def test_fcm_send_message(self):
@@ -225,7 +237,9 @@ class GCMModelTestCase(TestCase):
 				json.dumps({
 					"notification": {"body": "Hello world"},
 					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_fcm_send_message_extra_data(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
@@ -238,7 +252,9 @@ class GCMModelTestCase(TestCase):
 					"data": {"foo": "bar"},
 					"notification": {"body": "Hello world"},
 					"registration_ids": ["abc"],
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",
+				application_id=None
+			)
 
 	def test_fcm_send_message_extra_options(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
@@ -251,7 +267,9 @@ class GCMModelTestCase(TestCase):
 					"collapse_key": "test_key",
 					"notification": {"body": "Hello world"},
 					"registration_ids": ["abc"],
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json",
+				application_id=None
+			)
 
 	def test_fcm_send_message_extra_notification(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
@@ -263,7 +281,9 @@ class GCMModelTestCase(TestCase):
 				json.dumps({
 					"notification": {"body": "Hello world", "title": "test", "icon": "test_icon"},
 					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_fcm_send_message_extra_options_and_notification_and_data(self):
 		device = GCMDevice.objects.create(registration_id="abc", cloud_message_type="FCM")
@@ -282,7 +302,9 @@ class GCMModelTestCase(TestCase):
 					"data": {"foo": "bar"},
 					"registration_ids": ["abc"],
 					"collapse_key": "test_key"
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_fcm_send_message_to_multiple_devices(self):
 		self._create_fcm_devices(["abc", "abc1"])
@@ -295,7 +317,9 @@ class GCMModelTestCase(TestCase):
 				json.dumps({
 					"notification": {"body": "Hello world"},
 					"registration_ids": ["abc", "abc1"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_fcm_send_message_active_devices(self):
 		GCMDevice.objects.create(registration_id="abc", active=True, cloud_message_type="FCM")
@@ -309,7 +333,9 @@ class GCMModelTestCase(TestCase):
 				json.dumps({
 					"notification": {"body": "Hello world"},
 					"registration_ids": ["abc"]
-				}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+				}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+				"application/json", application_id=None
+			)
 
 	def test_fcm_send_message_collapse_to_multiple_devices(self):
 		self._create_fcm_devices(["abc", "abc1"])
@@ -323,7 +349,9 @@ class GCMModelTestCase(TestCase):
 						"collapse_key": "test_key",
 						"notification": {"body": "Hello world"},
 						"registration_ids": ["abc", "abc1"]
-					}, separators=(",", ":"), sort_keys=True).encode("utf-8"), "application/json")
+					}, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+					"application/json", application_id=None
+				)
 
 	def test_fcm_send_message_to_single_device_with_error(self):
 		# these errors are device specific, device.active will be set false
@@ -424,9 +452,10 @@ class GCMModelTestCase(TestCase):
 
 		with mock.patch("push_notifications.gcm._cm_send_request", return_value="") as p:
 			reg_ids = [obj.registration_id for obj in GCMDevice.objects.all()]
-			send_bulk_message(reg_ids, {"message": "Hello World"}, "GCM")
+			send_bulk_message(reg_ids, {"message": "Hello World"}, "FCM")
 			p.assert_called_once_with(
-				[u"abc", u"abc1"], {"message": "Hello World"}, cloud_type="GCM"
+				[u"abc", u"abc1"], {"message": "Hello World"}, cloud_type="FCM",
+				application_id=None
 			)
 
 	def test_can_save_wsn_device(self):

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -15,6 +15,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "AEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAEAE",
 			"name": "Apple iPhone 6+",
 			"device_id": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -23,6 +24,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "aeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeaeae",
 			"name": "Apple iPhone 6+",
 			"device_id": "ffffffffffffffffffffffffffffffff",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -47,6 +49,7 @@ class APNSDeviceSerializerTestCase(TestCase):
 			"registration_id": "invalid device token contains no hex",
 			"name": "Apple iPhone 6+",
 			"device_id": "ffffffffffffffffffffffffffffake",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 
@@ -57,6 +60,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())
 
@@ -68,6 +72,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		serializer.is_valid(raise_exception=True)
 		obj = serializer.save()
@@ -77,6 +82,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 5",
 			"device_id": "0x1031af3b",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		serializer.is_valid(raise_exception=True)
 		obj = serializer.save()
@@ -86,6 +92,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0xdeadbeaf",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 
 		with self.assertRaises(ValidationError):
@@ -96,6 +103,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "0x10r",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors, GCM_DRF_INVALID_HEX_ERROR)
@@ -105,6 +113,7 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Galaxy Note 3",
 			"device_id": "10000000000000000",  # 2**64
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertFalse(serializer.is_valid())
 		self.assertEqual(serializer.errors, GCM_DRF_OUT_OF_RANGE_ERROR)
@@ -117,5 +126,6 @@ class GCMDeviceSerializerTestCase(TestCase):
 			"registration_id": "foobar",
 			"name": "Nexus 5",
 			"device_id": "e87a4e72d634997c",
+			"application_id": "XXXXXXXXXXXXXXXXXXXX",
 		})
 		self.assertTrue(serializer.is_valid())

--- a/tests/test_wns.py
+++ b/tests/test_wns.py
@@ -14,13 +14,25 @@ class WNSSendMessageTestCase(TestCase):
 	@mock.patch("push_notifications.wns._wns_send")
 	def test_send_message_calls_wns_send_with_toast(self, mock_method, _):
 		wns_send_message(uri="one", message="test message")
-		mock_method.assert_called_with(uri="one", data="this is expected", wns_type="wns/toast")
+		mock_method.assert_called_with(
+			application_id=None, uri="one", data="this is expected", wns_type="wns/toast"
+		)
+
+	@mock.patch("push_notifications.wns._wns_prepare_toast", return_value="this is expected")
+	@mock.patch("push_notifications.wns._wns_send")
+	def test_send_message_calls_wns_send_with_application_id(self, mock_method, _):
+		wns_send_message(uri="one", message="test message", application_id="123456")
+		mock_method.assert_called_with(
+			application_id="123456", uri="one", data="this is expected", wns_type="wns/toast"
+		)
 
 	@mock.patch("push_notifications.wns.dict_to_xml_schema", return_value=ET.Element("toast"))
 	@mock.patch("push_notifications.wns._wns_send")
 	def test_send_message_calls_wns_send_with_xml(self, mock_method, _):
 		wns_send_message(uri="one", xml_data={"key": "value"})
-		mock_method.assert_called_with(uri="one", data=b"<toast />", wns_type="wns/toast")
+		mock_method.assert_called_with(
+			application_id=None, uri="one", data=b"<toast />", wns_type="wns/toast"
+		)
 
 	def test_send_message_raises_TypeError_if_one_of_the_data_params_arent_filled(self):
 		with self.assertRaises(TypeError):
@@ -40,7 +52,7 @@ class WNSSendBulkMessageTestCase(TestCase):
 	def test_send_bulk_message_calls_send_message(self, mock_method):
 		wns_send_bulk_message(uri_list=["one", ], message="test message")
 		mock_method.assert_called_with(
-			message="test message", raw_data=None, uri="one", xml_data=None
+			application_id=None, message="test message", raw_data=None, uri="one", xml_data=None
 		)
 
 


### PR DESCRIPTION
Provides backwards compatibility through conf adapters that determine which settings are supported and where the data can be loaded from. This implementation adds three:

  * LegacyConfig - supports the existing settings format
  * AppConfig - supports a dictionary of application_ids and their settings
  * AppModelConfig - supports storing the settings in the database for multiple apps

@jleclanche Consider this a really rough draft. I haven't had much time to test it though the tests pass.  I hope this gives you an idea of what I intend and should replace the other mutli application PR. This one has stubs for the multi-app config and multi-app in a model config. I'd like to get this approved and into the merged with the legacy config adapter just to reduce the number of rebases.