### PR TITLE
Fix 'APNS_TOPIC' docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ For WNS, you need both the ``WNS_PACKAGE_SECURITY_KEY`` and the ``WNS_SECRET_KEY
 **APNS settings**
 
 - ``APNS_CERTIFICATE``: Absolute path to your APNS certificate file. Certificates with passphrases are not supported.
-- ``APNS_TOPIC``: The topic of the remote notification, which is typically the bundle ID for your app. If you omit this header and your APNs certificate does not specify multiple topics, the APNs server uses the certificate’s Subject as the default topic.
+- ``APNS_TOPIC``: The topic of the remote notification, which is typically the bundle ID for your app.
 - ``APNS_USE_ALTERNATIVE_PORT``: Use port 2197 for APNS, instead of default port 443.
 - ``APNS_USE_SANDBOX``: Use 'api.development.push.apple.com', instead of default host 'api.push.apple.com'.
 


### PR DESCRIPTION
Passing `topic=...` to PyAPNS2 is mandatory (see https://github.com/Pr0Ger/PyAPNs2/issues/29), the topic isn't auto-guessed from the certificate.
An emtpy APNS_TOPIC setting leads to TopicDisallowed / MissingTopic errors.