### PR TITLE
Unmasked 'application_id' field in DRF GCMDeviceSerializer

### DIFF
--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -101,7 +101,7 @@ class GCMDeviceSerializer(UniqueRegistrationSerializerMixin, ModelSerializer):
 		model = GCMDevice
 		fields = (
 			"id", "name", "registration_id", "device_id", "active", "date_created",
-			"cloud_message_type", 'application_id',
+			"cloud_message_type", "application_id",
 		)
 		extra_kwargs = {"id": {"read_only": False, "required": False}}
 

--- a/push_notifications/api/rest_framework.py
+++ b/push_notifications/api/rest_framework.py
@@ -101,7 +101,7 @@ class GCMDeviceSerializer(UniqueRegistrationSerializerMixin, ModelSerializer):
 		model = GCMDevice
 		fields = (
 			"id", "name", "registration_id", "device_id", "active", "date_created",
-			"cloud_message_type",
+			"cloud_message_type", 'application_id',
 		)
 		extra_kwargs = {"id": {"read_only": False, "required": False}}
 


### PR DESCRIPTION
DRF GCMDeviceSerializer masks `application_id` field, making it **not available on DRF** views/urls.
To fix it we should either add `application_id` to `fields` or remove the `fields` from Meta class entirely.
APNSDeviceSerializer is not affected by this bug.
In this PR i just added it to fields, but it can also be done in the other way.