### PR TITLE
Remove push_notifications.utils

### DIFF
--- a/push_notifications/utils.py
+++ b/push_notifications/utils.py
@@ -1,7 +1,0 @@
-from .apns import apns_fetch_inactive_ids
-
-
-# This is an APNS-only function right now, but maybe GCM will implement it
-# in the future.  But the definition of 'expired' may not be the same.
-def get_expired_tokens(application_id):
-	return apns_fetch_inactive_ids(application_id)


### PR DESCRIPTION
It only contains `get_expired_tokens`, which is not importable anymore,
since apns_fetch_inactive_ids has been removed in 3998996.

Ref: https://github.com/jleclanche/django-push-notifications/issues/389